### PR TITLE
Add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #3

## Summary
- Add .github/dependabot.yml for automated GitHub Actions version updates (weekly)
- CompatHelper.yml was already absent from this repository