### PR TITLE
fix: Fix overlapping legends and layout in wave polarization SVGs (#19)

### DIFF
--- a/docs/src/assets/wave_polarizations_1d.svg
+++ b/docs/src/assets/wave_polarizations_1d.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 470 230">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
@@ -12,10 +12,10 @@
   </defs>
 
   <!-- Background -->
-  <rect width="600" height="200" fill="#fafafa"/>
+  <rect width="470" height="230" fill="#fafafa"/>
 
   <!-- Title -->
-  <text x="300" y="25" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#333">1D Wave Types</text>
+  <text x="235" y="25" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#333">1D Wave Types</text>
 
   <!-- ===== Photonic1D ===== -->
   <g transform="translate(50, 55)">
@@ -46,7 +46,7 @@
   </g>
 
   <!-- ===== Longitudinal1D ===== -->
-  <g transform="translate(350, 55)">
+  <g transform="translate(260, 55)">
     <text x="100" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#16a34a">Longitudinal1D</text>
     <text x="100" y="15" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">(Elastic P-wave)</text>
 
@@ -74,14 +74,14 @@
   </g>
 
   <!-- Legend at bottom -->
-  <g transform="translate(100, 175)">
+  <g transform="translate(30, 205)">
     <line x1="0" y1="0" x2="30" y2="0" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
     <text x="40" y="4" font-family="Arial, sans-serif" font-size="10" fill="#333">k: propagation</text>
 
     <line x1="150" y1="0" x2="180" y2="0" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
     <text x="190" y="4" font-family="Arial, sans-serif" font-size="10" fill="#2563eb">E: electric field</text>
 
-    <line x1="320" y1="0" x2="350" y2="0" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-    <text x="360" y="4" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u: displacement</text>
+    <line x1="300" y1="0" x2="330" y2="0" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+    <text x="340" y="4" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u: displacement</text>
   </g>
 </svg>

--- a/docs/src/assets/wave_polarizations_2d.svg
+++ b/docs/src/assets/wave_polarizations_2d.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 490 435">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
@@ -15,10 +15,10 @@
   </defs>
 
   <!-- Background -->
-  <rect width="600" height="360" fill="#fafafa"/>
+  <rect width="490" height="435" fill="#fafafa"/>
 
   <!-- Title -->
-  <text x="300" y="25" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#333">2D Wave Polarizations</text>
+  <text x="235" y="25" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#333">2D Wave Polarizations</text>
 
   <!-- ===== 2D Photonic (TE/TM) ===== -->
   <g transform="translate(50, 50)">
@@ -29,64 +29,64 @@
       <text x="100" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">TEWave</text>
 
       <!-- Coordinate frame -->
-      <rect x="30" y="15" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
+      <rect x="30" y="10" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
 
       <!-- Axes -->
-      <line x1="40" y1="105" x2="40" y2="25" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <line x1="40" y1="105" x2="160" y2="105" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <text x="35" y="20" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
-      <text x="165" y="108" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
+      <line x1="40" y1="100" x2="40" y2="20" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <line x1="40" y1="100" x2="160" y2="100" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <text x="35" y="15" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
+      <text x="165" y="103" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
 
       <!-- k vector (propagation) -->
-      <line x1="60" y1="90" x2="130" y2="50" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="135" y="55" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
+      <line x1="60" y1="85" x2="130" y2="45" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
+      <text x="135" y="50" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
 
       <!-- E field (in-plane, perpendicular to k) -->
-      <line x1="95" y1="70" x2="60" y2="40" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
-      <text x="50" y="35" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#2563eb">E</text>
+      <line x1="95" y1="65" x2="60" y2="35" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
+      <text x="50" y="30" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#2563eb">E</text>
 
       <!-- H field (out of plane, z direction) -->
-      <circle cx="95" cy="70" r="10" fill="none" stroke="#dc2626" stroke-width="2"/>
-      <circle cx="95" cy="70" r="3" fill="#dc2626"/>
-      <text x="110" y="65" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#dc2626">H_z</text>
+      <circle cx="95" cy="65" r="10" fill="none" stroke="#dc2626" stroke-width="2"/>
+      <circle cx="95" cy="65" r="3" fill="#dc2626"/>
+      <text x="110" y="80" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#dc2626">H_z</text>
 
       <!-- Description -->
-      <text x="100" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">E ∈ xy-plane, H ∥ z</text>
+      <text x="100" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">E ∈ xy-plane, H ∥ z</text>
     </g>
 
     <!-- TM Wave -->
-    <g transform="translate(0, 170)">
+    <g transform="translate(0, 180)">
       <text x="100" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">TMWave</text>
 
       <!-- Coordinate frame -->
-      <rect x="30" y="15" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
+      <rect x="30" y="10" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
 
       <!-- Axes -->
-      <line x1="40" y1="105" x2="40" y2="25" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <line x1="40" y1="105" x2="160" y2="105" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <text x="35" y="20" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
-      <text x="165" y="108" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
+      <line x1="40" y1="100" x2="40" y2="20" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <line x1="40" y1="100" x2="160" y2="100" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <text x="35" y="15" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
+      <text x="165" y="103" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
 
       <!-- k vector (propagation) -->
-      <line x1="60" y1="90" x2="130" y2="50" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="135" y="55" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
+      <line x1="60" y1="85" x2="130" y2="45" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
+      <text x="135" y="50" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
 
       <!-- H field (in-plane, perpendicular to k) -->
-      <line x1="95" y1="70" x2="60" y2="40" stroke="#dc2626" stroke-width="2" marker-end="url(#arrowhead-red)"/>
-      <text x="50" y="35" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#dc2626">H</text>
+      <line x1="95" y1="65" x2="60" y2="35" stroke="#dc2626" stroke-width="2" marker-end="url(#arrowhead-red)"/>
+      <text x="50" y="30" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#dc2626">H</text>
 
       <!-- E field (out of plane, z direction) -->
-      <circle cx="95" cy="70" r="10" fill="none" stroke="#2563eb" stroke-width="2"/>
-      <circle cx="95" cy="70" r="3" fill="#2563eb"/>
-      <text x="110" y="65" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#2563eb">E_z</text>
+      <circle cx="95" cy="65" r="10" fill="none" stroke="#2563eb" stroke-width="2"/>
+      <circle cx="95" cy="65" r="3" fill="#2563eb"/>
+      <text x="110" y="80" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#2563eb">E_z</text>
 
       <!-- Description -->
-      <text x="100" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">H ∈ xy-plane, E ∥ z</text>
+      <text x="100" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">H ∈ xy-plane, E ∥ z</text>
     </g>
   </g>
 
   <!-- ===== 2D Phononic (SH/P-SV) ===== -->
-  <g transform="translate(350, 50)">
+  <g transform="translate(220, 50)">
     <text x="100" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#333">Phononic</text>
 
     <!-- SH Wave -->
@@ -94,69 +94,71 @@
       <text x="100" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">SHWave</text>
 
       <!-- Coordinate frame -->
-      <rect x="30" y="15" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
+      <rect x="30" y="10" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
 
       <!-- Axes -->
-      <line x1="40" y1="105" x2="40" y2="25" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <line x1="40" y1="105" x2="160" y2="105" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <text x="35" y="20" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
-      <text x="165" y="108" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
+      <line x1="40" y1="100" x2="40" y2="20" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <line x1="40" y1="100" x2="160" y2="100" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <text x="35" y="15" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
+      <text x="165" y="103" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
 
       <!-- k vector (propagation) -->
-      <line x1="60" y1="90" x2="130" y2="50" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="135" y="55" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
+      <line x1="60" y1="85" x2="130" y2="45" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
+      <text x="135" y="50" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
 
       <!-- u field (out of plane, z direction) -->
-      <circle cx="95" cy="70" r="10" fill="none" stroke="#16a34a" stroke-width="2"/>
-      <circle cx="95" cy="70" r="3" fill="#16a34a"/>
-      <text x="110" y="65" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#16a34a">u_z</text>
+      <circle cx="95" cy="65" r="10" fill="none" stroke="#16a34a" stroke-width="2"/>
+      <circle cx="95" cy="65" r="3" fill="#16a34a"/>
+      <text x="110" y="80" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#16a34a">u_z</text>
 
       <!-- Description -->
-      <text x="100" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">Shear Horizontal (u ∥ z)</text>
+      <text x="100" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">Shear Horizontal (u ∥ z)</text>
     </g>
 
     <!-- P-SV Wave -->
-    <g transform="translate(0, 170)">
+    <g transform="translate(0, 180)">
       <text x="100" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">PSVWave</text>
 
       <!-- Coordinate frame -->
-      <rect x="30" y="15" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
+      <rect x="30" y="10" width="140" height="100" fill="none" stroke="#ddd" stroke-width="1"/>
 
       <!-- Axes -->
-      <line x1="40" y1="105" x2="40" y2="25" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <line x1="40" y1="105" x2="160" y2="105" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
-      <text x="35" y="20" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
-      <text x="165" y="108" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
+      <line x1="40" y1="100" x2="40" y2="20" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <line x1="40" y1="100" x2="160" y2="100" stroke="#999" stroke-width="1" marker-end="url(#arrowhead)"/>
+      <text x="35" y="15" font-family="Arial, sans-serif" font-size="9" fill="#999">y</text>
+      <text x="165" y="103" font-family="Arial, sans-serif" font-size="9" fill="#999">x</text>
 
       <!-- k vector (propagation) -->
-      <line x1="60" y1="90" x2="130" y2="50" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
-      <text x="135" y="55" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
+      <line x1="60" y1="85" x2="130" y2="45" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
+      <text x="135" y="50" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#333">k</text>
 
       <!-- u_parallel (P-wave, longitudinal) -->
-      <line x1="80" y1="80" x2="115" y2="55" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-      <text x="120" y="50" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u_∥</text>
+      <line x1="95" y1="65" x2="123" y2="49" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+      <text x="105" y="75" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u_∥</text>
 
       <!-- u_perpendicular (SV-wave, transverse) -->
-      <line x1="95" y1="70" x2="60" y2="40" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-      <text x="50" y="35" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u_⊥</text>
+      <line x1="95" y1="65" x2="60" y2="35" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+      <text x="50" y="30" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u_⊥</text>
 
       <!-- Description -->
-      <text x="100" y="130" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">In-plane (P: u∥k, SV: u⊥k)</text>
+      <text x="100" y="125" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">In-plane (P: u∥k, SV: u⊥k)</text>
     </g>
   </g>
 
-  <!-- Legend at bottom -->
-  <g transform="translate(50, 335)">
+  <!-- Legend at bottom (2 rows) -->
+  <g transform="translate(30, 395)">
+    <!-- Row 1: k, E, u -->
     <line x1="0" y1="0" x2="30" y2="0" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
     <text x="40" y="4" font-family="Arial, sans-serif" font-size="10" fill="#333">k: propagation</text>
 
-    <line x1="140" y1="0" x2="170" y2="0" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
-    <text x="180" y="4" font-family="Arial, sans-serif" font-size="10" fill="#2563eb">E: electric field</text>
+    <line x1="150" y1="0" x2="180" y2="0" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
+    <text x="190" y="4" font-family="Arial, sans-serif" font-size="10" fill="#2563eb">E: electric field</text>
 
-    <line x1="290" y1="0" x2="320" y2="0" stroke="#dc2626" stroke-width="2" marker-end="url(#arrowhead-red)"/>
-    <text x="330" y="4" font-family="Arial, sans-serif" font-size="10" fill="#dc2626">H: magnetic field</text>
+    <line x1="320" y1="0" x2="350" y2="0" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+    <text x="360" y="4" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u: displacement</text>
 
-    <line x1="440" y1="0" x2="470" y2="0" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-    <text x="480" y="4" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u: displacement</text>
+    <!-- Row 2: H (below E) -->
+    <line x1="150" y1="18" x2="180" y2="18" stroke="#dc2626" stroke-width="2" marker-end="url(#arrowhead-red)"/>
+    <text x="190" y="22" font-family="Arial, sans-serif" font-size="10" fill="#dc2626">H: magnetic field</text>
   </g>
 </svg>

--- a/docs/src/assets/wave_polarizations_3d.svg
+++ b/docs/src/assets/wave_polarizations_3d.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 850 310">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 325">
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
@@ -15,10 +15,10 @@
   </defs>
 
   <!-- Background -->
-  <rect width="850" height="310" fill="#fafafa"/>
+  <rect width="640" height="325" fill="#fafafa"/>
 
   <!-- Title -->
-  <text x="425" y="25" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#333">3D Wave Polarizations</text>
+  <text x="320" y="25" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#333">3D Wave Polarizations</text>
 
   <!-- ===== TransverseEM (Recommended) ===== -->
   <g transform="translate(30, 70)">
@@ -65,7 +65,7 @@
   </g>
 
   <!-- ===== 3D Photonic (FullVectorEM) ===== -->
-  <g transform="translate(300, 70)">
+  <g transform="translate(225, 70)">
     <text x="120" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#333">FullVectorEM</text>
     <text x="120" y="15" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">(H_x, H_y, H_z)</text>
 
@@ -108,7 +108,7 @@
   </g>
 
   <!-- ===== 3D Phononic (FullElastic) ===== -->
-  <g transform="translate(570, 70)">
+  <g transform="translate(420, 70)">
     <text x="120" y="0" text-anchor="middle" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#333">FullElastic</text>
     <text x="120" y="15" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#666">(u_x, u_y, u_z)</text>
 
@@ -136,8 +136,8 @@
       <text x="145" y="38" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#333">k</text>
 
       <!-- P-wave (longitudinal, parallel to k) -->
-      <line x1="90" y1="63" x2="120" y2="43" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-      <text x="125" y="50" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="#16a34a">P</text>
+      <line x1="95" y1="62" x2="125" y2="47" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+      <text x="118" y="68" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="#16a34a">P</text>
 
       <!-- S-wave (transverse, perpendicular to k, two components) -->
       <line x1="105" y1="57" x2="80" y2="35" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
@@ -152,24 +152,29 @@
   </g>
 
   <!-- Legend and notes at bottom -->
-  <g transform="translate(50, 260)">
+  <g transform="translate(30, 260)">
+    <!-- Row 1: k, e₁e₂, u -->
     <line x1="0" y1="0" x2="30" y2="0" stroke="#333" stroke-width="2" marker-end="url(#arrowhead)"/>
     <text x="40" y="4" font-family="Arial, sans-serif" font-size="10" fill="#333">k: propagation</text>
 
-    <line x1="170" y1="0" x2="200" y2="0" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
-    <text x="210" y="4" font-family="Arial, sans-serif" font-size="10" fill="#2563eb">e₁,e₂: polarization basis</text>
+    <line x1="150" y1="0" x2="180" y2="0" stroke="#2563eb" stroke-width="2" marker-end="url(#arrowhead-blue)"/>
+    <text x="190" y="4" font-family="Arial, sans-serif" font-size="10" fill="#2563eb">e₁,e₂: polarization basis</text>
 
-    <line x1="380" y1="0" x2="410" y2="0" stroke="#dc2626" stroke-width="2" marker-end="url(#arrowhead-red)"/>
-    <text x="420" y="4" font-family="Arial, sans-serif" font-size="10" fill="#dc2626">H: magnetic field</text>
+    <line x1="380" y1="0" x2="410" y2="0" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+    <text x="420" y="4" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u: displacement</text>
 
-    <line x1="560" y1="0" x2="590" y2="0" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
-    <text x="600" y="4" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">u: displacement</text>
+    <!-- Row 2: H (below e₁e₂), P (below u) -->
+    <line x1="150" y1="18" x2="180" y2="18" stroke="#dc2626" stroke-width="2" marker-end="url(#arrowhead-red)"/>
+    <text x="190" y="22" font-family="Arial, sans-serif" font-size="10" fill="#dc2626">H: magnetic field</text>
+
+    <line x1="380" y1="18" x2="410" y2="18" stroke="#16a34a" stroke-width="2" marker-end="url(#arrowhead-green)"/>
+    <text x="420" y="22" font-family="Arial, sans-serif" font-size="10" fill="#16a34a">P: longitudinal, S: shear</text>
   </g>
 
   <!-- Note about modes -->
-  <g transform="translate(50, 285)">
-    <rect x="0" y="0" width="750" height="20" fill="#d1fae5" rx="3" stroke="#10b981" stroke-width="1"/>
-    <text x="375" y="14" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#065f46">
+  <g transform="translate(30, 300)">
+    <rect x="0" y="0" width="580" height="20" fill="#d1fae5" rx="3" stroke="#10b981" stroke-width="1"/>
+    <text x="290" y="14" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#065f46">
       TransverseEM: recommended for 3D photonic crystals — automatically satisfies ∇·H = 0, no spurious modes
     </text>
   </g>


### PR DESCRIPTION
## Summary
- Fix legend overlapping with diagram content in 1D, 2D, and 3D SVGs
- Reduce column spacing between photonic and phononic panels
- Restructure 2D/3D legends into two rows (E/H, u/P-S)
- Fix field labels (H_z, E_z, u_z, u_∥) overlapping with k vector
- Fix P-wave arrow to be parallel to k in 3D FullElastic

Closes #19