### PR TITLE
feat: Add band sorting and DOS/LDOS examples

### DIFF
--- a/docs/src/analysis.md
+++ b/docs/src/analysis.md
@@ -19,6 +19,38 @@ vg = group_velocity(solver, k; bands=1:4)
 # vg[i] = [∂ω/∂kx, ∂ω/∂ky] for band i
 ```
 
+## Band Tracking
+
+When bands cross or come close together, eigenvalue sorting by frequency can cause apparent discontinuities in the band structure. The `track_bands` option uses eigenvector overlap to maintain band continuity.
+
+```julia
+# Without tracking (default): bands sorted by frequency at each k-point
+bands = compute_bands(solver, kpath; bands=1:6)
+
+# With tracking: bands tracked using eigenvector overlap
+bands = compute_bands(solver, kpath; bands=1:6, track_bands=true)
+```
+
+**How it works:**
+1. At each k-point, compute overlap matrix between eigenvectors of adjacent k-points
+2. Find optimal permutation that maximizes diagonal overlap
+3. Reorder bands to maintain continuity
+
+**When to use:**
+- 3D calculations where band crossings are common
+- Near degeneracy points
+- When smooth band dispersion is needed for further analysis (e.g., group velocity)
+
+**Example: 3D FCC phononic crystal**
+```julia
+lat = fcc_lattice(1.0)
+geo = Geometry(lat, Epoxy, [(Sphere([0,0,0], 0.2), WC)])
+solver = Solver(FullElastic(), geo, (12,12,12), KrylovKitMethod(); cutoff=3)
+
+kpath = simple_kpath_fcc()
+bands = compute_bands(solver, kpath; bands=1:12, track_bands=true)
+```
+
 ## K-path Options
 
 ### Simple k-paths

--- a/docs/src/api-advanced.md
+++ b/docs/src/api-advanced.md
@@ -20,6 +20,12 @@ MatrixFreeEffectiveHamiltonian
 NegatedOperator
 ```
 
+## Band Tracking
+
+The `track_bands` option in [`compute_bands`](@ref) uses eigenvector overlap to maintain band continuity across k-points.
+
+See [Band Tracking](analysis.md#Band-Tracking) for usage examples.
+
 ## Green's Function and DOS/LDOS
 
 !!! note "Optional Dependency"

--- a/examples/000_examples.md
+++ b/examples/000_examples.md
@@ -68,7 +68,7 @@ automatically satisfies ∇·H = 0.
 |------|-------------|
 | 401_fcc_spheres.jl | FCC lattice spheres (3D photonic, TransverseEM) |
 | 402_sc_spheres.jl | SC lattice spheres (3D photonic, TransverseEM) |
-| 403_fcc_phononic.jl | FCC phononic (not included in v1) |
+| 403_fcc_phononic.jl | FCC phononic WC/Epoxy with band tracking |
 | 411_joannopoulos_ch6_fig3.jl | Diamond air spheres (Joannopoulos Ch.6 Fig.3) |
 | 412_joannopoulos_ch6_fig8.jl | Inverse opal (Joannopoulos Ch.6 Fig.8) |
 | 413_mpb_diamond.jl | MPB diamond tutorial (dielectric spheres) |
@@ -78,6 +78,9 @@ automatically satisfies ∇·H = 0.
 | File | Description |
 |------|-------------|
 | 501_defect_mode.jl | Defect mode / LDOS (DirectGF) |
+| 502_dos.jl | DOS calculation (DirectGF) |
+| 503_ldos_rsk.jl | LDOS at defect site (MatrixFreeGF) |
+| 504_dos_1d.jl | 1D DOS with band structure |
 | 511_supercell_study.jl | Supercell study |
 
 ### 6xx: Transfer Matrix Method (TMM)

--- a/examples/403_fcc_phononic.jl
+++ b/examples/403_fcc_phononic.jl
@@ -1,0 +1,184 @@
+# 3D FCC Phononic Crystal - Tungsten Carbide spheres in Epoxy
+# Reference: Lu et al., Scientific Reports 7, 43407 (2017)
+#            "3-D phononic crystals with ultra-wide band gaps"
+#
+# Material: WC spheres (ρ=13800, E=387.56 GPa, ν=0.346) in Epoxy matrix
+# Expected result: ~93.3% normalized band gap between bands 6-7 at f=0.588
+
+using PhoXonic
+using LinearAlgebra
+using Plots
+default(guidefontsize=14, tickfontsize=12, titlefontsize=14, left_margin=10Plots.mm, right_margin=10Plots.mm, top_margin=5Plots.mm, bottom_margin=10Plots.mm)
+
+println("=" ^ 60)
+println("3D FCC Phononic Crystal: WC spheres in Epoxy")
+println("Reference: Lu et al., Sci. Rep. 7, 43407 (2017)")
+println("=" ^ 60)
+println()
+
+# FCC lattice
+a = 1.0  # conventional lattice constant (normalized)
+lat = fcc_lattice(a)
+
+println("Structure: FCC lattice")
+println("  Conventional lattice constant: a = $a")
+println("  Primitive vectors:")
+for (i, v) in enumerate(lat.vectors)
+    println("    a$i = ", round.(v; digits=4))
+end
+
+# Material parameters from Lu et al. Scientific Reports 7, 43407 (2017)
+# Tungsten Carbide (WC): ρ = 13800 kg/m³, E = 387.5559 GPa, ν = 0.3459
+# Epoxy:                 ρ = 1180 kg/m³,  E = 4.3438 GPa,   ν = 0.3679
+#
+# Normalize by epoxy properties
+ρ_epoxy_real = 1180.0      # kg/m³
+E_epoxy_real = 4.3438e9    # Pa
+
+# Normalized values (epoxy as reference)
+ρ_WC = 13800.0 / ρ_epoxy_real    # ~11.69
+ρ_epoxy = 1.0
+
+# Create materials using from_E_ν (exact values from paper)
+WC = from_E_ν(ρ_WC, 387.5559e9 / E_epoxy_real, 0.3459)
+epoxy = from_E_ν(ρ_epoxy, 1.0, 0.3679)
+
+println("\nMaterial parameters (normalized by epoxy):")
+println("  WC sphere:   ρ = $(round(WC.ρ, digits=2)), C11 = $(round(WC.C11, digits=2)), C44 = $(round(WC.C44, digits=2))")
+println("  Epoxy matrix: ρ = $(round(epoxy.ρ, digits=2)), C11 = $(round(epoxy.C11, digits=2)), C44 = $(round(epoxy.C44, digits=2))")
+
+# Contrast ratio
+println("\nContrast ratios:")
+println("  ρ_WC / ρ_epoxy = $(round(WC.ρ / epoxy.ρ, digits=1))")
+println("  C11_WC / C11_epoxy = $(round(WC.C11 / epoxy.C11, digits=1))")
+println("  C44_WC / C44_epoxy = $(round(WC.C44 / epoxy.C44, digits=1))")
+
+# Wave velocities
+v_L_WC = sqrt(WC.C11 / WC.ρ)
+v_T_WC = sqrt(WC.C44 / WC.ρ)
+v_L_epoxy = sqrt(epoxy.C11 / epoxy.ρ)
+v_T_epoxy = sqrt(epoxy.C44 / epoxy.ρ)
+println("\nWave velocities (normalized):")
+println("  WC:    v_L = $(round(v_L_WC, digits=2)), v_T = $(round(v_T_WC, digits=2))")
+println("  Epoxy: v_L = $(round(v_L_epoxy, digits=2)), v_T = $(round(v_T_epoxy, digits=2))")
+
+# Optimal filling fraction f = 0.588 for maximum band gap (Lu et al. Table 1)
+# For FCC with sphere at origin: f = (4π/3)r³ / V_primitive
+# V_primitive = a³/4 for FCC
+# f = (4π/3)r³ / (a³/4) = (16π/3)(r/a)³
+# For f = 0.588: r/a = (3f/16π)^(1/3) ≈ 0.327
+filling_target = 0.588
+radius = a * (3 * filling_target / (16π))^(1 / 3)  # ≈ 0.327a
+
+# Volume fraction calculation
+V_primitive = a^3 / 4  # FCC primitive cell volume
+V_sphere = (4π / 3) * radius^3
+filling_fraction = V_sphere / V_primitive
+
+println("\nGeometry:")
+println("  Sphere radius: r/a = $(round(radius/a, digits=3))")
+println("  Filling fraction: f = $(round(filling_fraction, digits=3))")
+
+# WC spheres in epoxy matrix
+geo = Geometry(lat, epoxy, [(Sphere([0.0, 0.0, 0.0], radius), WC)])
+
+# Solver setup (higher resolution for 3D convergence)
+resolution = (16, 16, 16)
+cutoff = 7
+shift = 0.1
+
+println("\nSolver configuration:")
+println("  Wave type: FullElastic (3N DOF)")
+println("  Resolution: $resolution")
+println("  Cutoff: $cutoff")
+
+solver = Solver(FullElastic(), geo, resolution, KrylovKitMethod(; shift=shift); cutoff=cutoff)
+println("  Plane waves: ", solver.basis.num_pw)
+println("  Matrix size: ", 3 * solver.basis.num_pw, " × ", 3 * solver.basis.num_pw)
+
+# K-path for FCC: Γ → X → W → L → Γ → K
+kpath = simple_kpath_fcc(; a=a, npoints=12)
+println("\nK-path: Γ → X → W → L → Γ → K")
+println("K-points: ", length(kpath))
+
+# Compute bands (need at least 8 bands to see gap between 6-7)
+nbands = 10
+println("\nComputing $nbands bands...")
+println("(This may take several minutes for 3D elastic calculations)")
+# Use track_bands=true for smooth band tracking across k-points
+bands_result = compute_bands(solver, kpath; bands=1:nbands, verbose=true, track_bands=true)
+
+# Find band gaps
+println("\n=== Band Gaps ===")
+gaps = find_all_gaps(bands_result; threshold=0.01)
+if isempty(gaps)
+    println("No complete band gap found.")
+    println("Note: May need higher resolution or different parameters")
+else
+    for g in gaps
+        gap_pct = round(g.gap_ratio * 100; digits=1)
+        println("Gap between bands $(g.bands): $(gap_pct)% gap-to-midgap")
+    end
+end
+
+println("\n=== Expected (Lu et al. 2017, Table 1) ===")
+println("~93.3% gap-to-midgap for FCC WC/Epoxy spherical inclusions at f=0.588")
+println("(Gap between bands 6-7)")
+
+# Normalize frequencies
+freqs_normalized = bands_result.frequencies
+dists = bands_result.distances
+
+# Plot
+p = plot(;
+    size=(700, 500),
+    xlabel="Wave vector",
+    ylabel="Frequency ω (normalized)",
+    title="3D FCC Phononic: WC/Epoxy (f=0.588)",
+    legend=false,
+    grid=true,
+    framestyle=:box,
+)
+
+# Find and highlight band gap if exists
+if !isempty(gaps)
+    g = gaps[1]
+    gap_bottom = maximum(freqs_normalized[:, g.bands[1]])
+    gap_top = minimum(freqs_normalized[:, g.bands[2]])
+    plot!(
+        p,
+        [dists[1], dists[end], dists[end], dists[1], dists[1]],
+        [gap_bottom, gap_bottom, gap_top, gap_top, gap_bottom];
+        fillrange=gap_bottom,
+        fillalpha=0.3,
+        fillcolor=:lightgreen,
+        linecolor=:green,
+        linewidth=1,
+        label="",
+    )
+    annotate!(
+        p,
+        (dists[1] + dists[end]) / 2,
+        (gap_bottom + gap_top) / 2,
+        text("Complete Band Gap", 8),
+    )
+end
+
+# Plot bands as lines
+for b in 1:size(freqs_normalized, 2)
+    plot!(p, dists, freqs_normalized[:, b]; linewidth=1.5, color=:blue, label="")
+end
+
+# Add vertical lines at high-symmetry points
+for (idx, label) in bands_result.labels
+    vline!(p, [dists[idx]]; color=:gray, linestyle=:solid, alpha=0.5, linewidth=0.5)
+end
+
+# Add x-axis labels
+label_positions = [dists[idx] for (idx, _) in bands_result.labels]
+label_names = [label for (_, label) in bands_result.labels]
+plot!(p; xticks=(label_positions, label_names))
+
+output_file = joinpath(@__DIR__, "403_fcc_phononic_bands.png")
+savefig(p, output_file)
+println("\nSaved: $output_file")

--- a/examples/502_dos.jl
+++ b/examples/502_dos.jl
@@ -1,0 +1,131 @@
+# DOS calculation for 2D photonic crystal
+# Compares band structure with density of states
+#
+# Note: For RSKGF/MatrixFreeGF methods, load ReducedShiftedKrylov.jl
+
+using PhoXonic
+using Plots
+
+default(
+    guidefontsize=14,
+    tickfontsize=12,
+    titlefontsize=14,
+    left_margin=10Plots.mm,
+    right_margin=10Plots.mm,
+    bottom_margin=10Plots.mm,
+)
+
+println("Example 502: DOS Calculation")
+println("=" ^ 50)
+
+# 2D photonic crystal - square lattice with dielectric rods
+lat = square_lattice(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Circle([0.5, 0.5], 0.3), Dielectric(9.0))
+])
+solver = Solver(TMWave(), geo, (32, 32); cutoff=5)
+
+println("Structure: Square lattice with dielectric rods")
+println("Solver: TMWave, 32x32 grid, cutoff=5")
+println("Plane waves: $(solver.basis.num_pw)")
+
+# Compute band structure
+println("\nComputing band structure...")
+kpath = simple_kpath_square(; npoints=31)
+bands_result = compute_bands(solver, kpath; bands=1:6)
+
+# Frequency range for DOS
+ω_max = maximum(bands_result.frequencies) * 1.1
+ω_values = range(0.05, ω_max, length=100)
+
+# K-points for BZ sampling
+k_points = [[i/8, j/8] for i in 0:7 for j in 0:7]
+
+println("Computing DOS ($(length(ω_values)) frequencies, $(length(k_points)) k-points)...")
+t_dos = @elapsed dos_result = compute_dos(solver, ω_values, k_points, DirectGF(); η=0.02)
+println("  Time: $(round(t_dos, digits=2)) s")
+
+# Find band gaps
+gaps = find_all_gaps(bands_result; threshold=0.01)
+println("\nBand gaps: $(length(gaps))")
+for g in gaps
+    gap_pct = round(g.gap_ratio * 100; digits=1)
+    println("  Bands $(g.bands): $(gap_pct)% gap-to-midgap")
+end
+
+# Plot
+p = plot(layout=(1, 2), size=(1000, 450))
+
+# Left: Band structure
+dists = bands_result.distances
+freqs = bands_result.frequencies
+
+for b in 1:size(freqs, 2)
+    plot!(p, dists, freqs[:, b];
+        subplot=1,
+        label="",
+        linewidth=1.5,
+        color=:blue,
+    )
+end
+
+# Shade band gaps
+for g in gaps
+    plot!(p,
+        [dists[1], dists[end], dists[end], dists[1], dists[1]],
+        [g.max_lower, g.max_lower, g.min_upper, g.min_upper, g.max_lower];
+        subplot=1,
+        fillrange=g.max_lower,
+        fillalpha=0.3,
+        fillcolor=:lightgreen,
+        linecolor=:green,
+        linewidth=1,
+        label="",
+    )
+end
+
+# High-symmetry point labels
+label_positions = [dists[idx] for (idx, _) in bands_result.labels]
+label_names = [label for (_, label) in bands_result.labels]
+for pos in label_positions
+    vline!(p, [pos]; subplot=1, color=:gray, linestyle=:dot, alpha=0.5, label="")
+end
+
+plot!(p;
+    subplot=1,
+    xlabel="Wave vector",
+    ylabel="Frequency ω",
+    title="Band Structure",
+    xticks=(label_positions, label_names),
+    legend=false,
+)
+
+# Right: DOS
+plot!(p, dos_result, ω_values;
+    subplot=2,
+    label="",
+    linewidth=2,
+    color=:blue,
+)
+
+# Mark band gaps in DOS
+for g in gaps
+    hspan!(p, [g.max_lower, g.min_upper];
+        subplot=2,
+        alpha=0.3,
+        color=:lightgreen,
+        label="",
+    )
+end
+
+plot!(p;
+    subplot=2,
+    xlabel="DOS (arb. units)",
+    ylabel="Frequency ω",
+    title="Density of States",
+    legend=false,
+)
+
+output_file = joinpath(@__DIR__, "502_dos_rsk.png")
+savefig(p, output_file)
+println("\nSaved: $output_file")

--- a/examples/503_ldos_rsk.jl
+++ b/examples/503_ldos_rsk.jl
@@ -1,0 +1,100 @@
+# LDOS calculation at defect site using RSK
+# Shows localized mode detection via LDOS peak
+#
+# Uses ReducedShiftedKrylov.jl extension
+
+using PhoXonic
+using ReducedShiftedKrylov  # Load RSK extension
+using Plots
+
+default(
+    guidefontsize=14,
+    tickfontsize=12,
+    titlefontsize=14,
+    left_margin=10Plots.mm,
+    right_margin=10Plots.mm,
+)
+
+println("Example 503: LDOS at Defect Site")
+println("=" ^ 50)
+
+# Unit cell geometry
+lat = square_lattice(1.0)
+geo_unit = Geometry(lat, Dielectric(1.0), [
+    (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+])
+
+# 3x3 supercell with center rod removed (defect at position (1,1))
+geo = create_supercell(geo_unit, (3, 3); point_defects=[(1, 1)])
+
+solver = Solver(TMWave(), geo, (48, 48); cutoff=5)
+
+println("Structure: 3x3 supercell with center rod removed")
+println("Solver: TMWave, 48x48 grid, cutoff=5")
+println("Plane waves: $(solver.basis.num_pw)")
+
+# Frequency range around expected defect mode
+ω_values = range(0.2, 0.6, length=50)
+
+# LDOS at defect center and away from defect (bulk site)
+pos_defect = [1.5, 1.5]  # Center of supercell (defect site)
+pos_bulk = [0.5, 0.5]    # Corner site (bulk-like)
+
+# Use Gamma point only for supercell
+k_points = [[0.0, 0.0]]
+
+println("\nComputing LDOS at defect site...")
+t_defect = @elapsed ldos_defect = compute_ldos(
+    solver, pos_defect, ω_values, k_points, MatrixFreeGF();
+    η=0.01
+)
+println("  Time: $(round(t_defect, digits=2)) s")
+
+println("Computing LDOS at bulk site...")
+t_bulk = @elapsed ldos_bulk = compute_ldos(
+    solver, pos_bulk, ω_values, k_points, MatrixFreeGF();
+    η=0.01
+)
+println("  Time: $(round(t_bulk, digits=2)) s")
+
+# Find peak in defect LDOS
+peak_idx = argmax(ldos_defect)
+peak_ω = ω_values[peak_idx]
+
+# Plot
+p = plot(size=(700, 500))
+plot!(p, ω_values, ldos_defect;
+    label="Defect site (1.5, 1.5)",
+    linewidth=2,
+    color=:red,
+)
+plot!(p, ω_values, ldos_bulk;
+    label="Bulk site (0.5, 0.5)",
+    linewidth=2,
+    linestyle=:dash,
+    color=:blue,
+)
+
+# Mark the peak
+vline!(p, [peak_ω];
+    linestyle=:dot,
+    color=:gray,
+    label="Peak at ω = $(round(peak_ω, digits=3))",
+)
+
+plot!(p;
+    xlabel="Frequency ω",
+    ylabel="LDOS (arb. units)",
+    title="LDOS: Defect Mode Detection in 2D Photonic Crystal",
+    legend=:topright,
+)
+
+output_file = joinpath(@__DIR__, "503_ldos_rsk.png")
+savefig(p, output_file)
+println("\nSaved: $output_file")
+
+println("\n=== Results ===")
+println("Defect mode frequency: ω ≈ $(round(peak_ω, digits=3))")
+println("Peak LDOS at defect: $(round(maximum(ldos_defect), digits=2))")
+println("Peak LDOS at bulk:   $(round(maximum(ldos_bulk), digits=2))")
+println("Enhancement ratio:   $(round(maximum(ldos_defect) / maximum(ldos_bulk), digits=1))x")

--- a/examples/504_dos_1d.jl
+++ b/examples/504_dos_1d.jl
@@ -1,0 +1,158 @@
+# 1D Photonic Crystal: Band Structure and DOS
+# Shows band gaps and corresponding DOS features
+#
+# Note: RSKGF is currently implemented for 2D/3D.
+# This example demonstrates basic DOS calculation for 1D.
+
+using PhoXonic
+using Plots
+
+default(
+    guidefontsize=14,
+    tickfontsize=12,
+    titlefontsize=14,
+    left_margin=10Plots.mm,
+    right_margin=10Plots.mm,
+)
+
+println("Example 504: 1D Photonic Crystal DOS")
+println("=" ^ 50)
+
+# 1D photonic crystal - Bragg stack
+lat = lattice_1d(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Segment(0.0, 0.3), Dielectric(9.0))
+])
+solver = Solver(Photonic1D(), geo, (64,); cutoff=10)
+
+println("Structure: 1D Bragg stack")
+println("Solver: Photonic1D, 64 grid, cutoff=10")
+println("Plane waves: $(solver.basis.num_pw)")
+
+# Frequency points for DOS
+ω_values = range(0.1, 5.0, length=100)
+
+# K-points for DOS sampling
+k_points = collect(range(0.0, 0.5, length=20))
+
+println("Frequencies: $(length(ω_values)) points")
+println("K-points: $(length(k_points))")
+println()
+
+# Compute DOS
+println("Computing DOS...")
+t_dos = @elapsed dos_result = compute_dos(solver, ω_values, k_points; η=0.05)
+println("  Time: $(round(t_dos, digits=2)) s")
+
+# Compute band structure (1D uses direct Vector of k-points)
+println("Computing band structure...")
+kpath = collect(range(0.0, 0.5, length=41))
+nbands = 5
+nk = length(kpath)
+frequencies = zeros(Float64, nk, nbands)
+
+for (ik, k) in enumerate(kpath)
+    ω, _ = solve(solver, k; bands=1:nbands)
+    frequencies[ik, :] = ω
+end
+
+# Find band gaps manually
+gaps = []
+for b in 1:(nbands-1)
+    max_lower = maximum(frequencies[:, b])
+    min_upper = minimum(frequencies[:, b+1])
+    gap = max(0.0, min_upper - max_lower)
+    if gap > 0.01
+        midgap = (min_upper + max_lower) / 2
+        gap_ratio = gap / midgap
+        push!(gaps, (bands=(b, b+1), gap=gap, gap_ratio=gap_ratio, min_upper=min_upper, max_lower=max_lower))
+    end
+end
+
+println("\nBand gaps found: $(length(gaps))")
+for g in gaps
+    gap_pct = round(g.gap_ratio * 100; digits=1)
+    println("  Bands $(g.bands): $(gap_pct)% gap-to-midgap at ω = $(round((g.min_upper + g.max_lower)/2, digits=2))")
+end
+
+# Plot
+p = plot(layout=(1, 2), size=(1000, 450))
+
+# Left: Band structure
+dists = kpath
+
+for b in 1:size(frequencies, 2)
+    plot!(p, dists, frequencies[:, b];
+        subplot=1,
+        label="",
+        linewidth=1.5,
+        color=:blue,
+    )
+end
+
+# Shade band gap regions
+for g in gaps
+    gap_bottom = g.max_lower
+    gap_top = g.min_upper
+    plot!(p,
+        [dists[1], dists[end], dists[end], dists[1], dists[1]],
+        [gap_bottom, gap_bottom, gap_top, gap_top, gap_bottom];
+        subplot=1,
+        fillrange=gap_bottom,
+        fillalpha=0.3,
+        fillcolor=:lightgreen,
+        linecolor=:green,
+        linewidth=1,
+        label="",
+    )
+end
+
+# High-symmetry point labels for 1D
+label_positions = [0.0, 0.5]
+label_names = ["Γ", "X"]
+
+# Add vertical lines at high-symmetry points
+for pos in label_positions
+    vline!(p, [pos]; subplot=1, color=:gray, linestyle=:dot, alpha=0.5, label="")
+end
+
+plot!(p;
+    subplot=1,
+    xlabel="Wave vector k (π/a)",
+    ylabel="Frequency ω",
+    title="1D Photonic Crystal Bands",
+    xticks=(label_positions, label_names),
+    legend=false,
+)
+
+# Right: DOS
+plot!(p, dos_result, ω_values;
+    subplot=2,
+    label="",
+    linewidth=2,
+    color=:blue,
+)
+
+# Mark band gap regions in DOS plot
+for g in gaps
+    gap_bottom = g.max_lower
+    gap_top = g.min_upper
+    hspan!(p, [gap_bottom, gap_top];
+        subplot=2,
+        alpha=0.3,
+        color=:lightgreen,
+        label="",
+    )
+end
+
+plot!(p;
+    subplot=2,
+    xlabel="DOS (arb. units)",
+    ylabel="Frequency ω",
+    title="Density of States",
+    legend=false,
+)
+
+output_file = joinpath(@__DIR__, "504_dos_1d.png")
+savefig(p, output_file)
+println("\nSaved: $output_file")

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -22,265 +22,19 @@ struct BandStructure{D}
     labels::Vector{Tuple{Int,String}}
 end
 
-"""
-    compute_bands(solver::Solver, kpath; bands=1:10, verbose=false)
+# ============================================================================
+# 2D Band structure computation
+# ============================================================================
 
-Compute band structure along a k-point path.
-
-When the solver uses LOBPCGMethod with warm_start=true, automatically:
-1. Solves first k-point with Dense (if first_dense=true)
-2. Uses previous eigenvectors as initial guess for subsequent k-points
-3. Applies matrix scaling (if scale=true)
-
-This can achieve up to 38x speedup for large problems.
-
-# Arguments
-- `solver`: The solver
-- `kpath`: K-point path (SimpleKPath, KPathInterpolant, or Vector)
-- `bands`: Which bands to compute (default: 1:10)
-- `verbose`: Print progress (default: false)
-
-# Returns
-A `BandStructure` object containing frequencies for each k-point and band.
-"""
-function compute_bands(
-    solver::Solver{Dim2}, kpath::SimpleKPath{2}; bands=1:10, verbose::Bool=false
-)
-    nk = length(kpath)
-    nbands = length(bands)
-    frequencies = zeros(Float64, nk, nbands)
-
-    # Check if warm start is enabled
-    method = solver.method
-    use_warm_start = method isa LOBPCGMethod && method.warm_start
-
-    if use_warm_start
-        _compute_bands_warmstart!(frequencies, solver, kpath.points, bands, verbose)
-    else
-        for (ik, k) in enumerate(kpath.points)
-            if verbose && ik % 10 == 0
-                println("Computing k-point $ik / $nk")
-            end
-            ω, _ = solve(solver, collect(k); bands=bands)
-            frequencies[ik, :] = ω
-        end
-    end
-
-    BandStructure{2}(kpath.points, kpath.distances, frequencies, kpath.labels)
-end
-
-"""
-    compute_bands(solver::Solver, kpoints::Vector; bands=1:10)
-
-Compute band structure at specified k-points (without path structure).
-"""
-function compute_bands(
-    solver::Solver{Dim2}, kpoints::Vector{<:AbstractVector}; bands=1:10, verbose::Bool=false
-)
-    nk = length(kpoints)
-    nbands = length(bands)
-    frequencies = zeros(Float64, nk, nbands)
-
-    for (ik, k) in enumerate(kpoints)
-        if verbose && ik % 10 == 0
-            println("Computing k-point $ik / $nk")
-        end
-        ω, _ = solve(solver, k; bands=bands)
-        frequencies[ik, :] = ω
-    end
-
-    # Create simple distance array
-    points = [SVector{2}(k...) for k in kpoints]
-    distances = Float64[0.0]
-    for i in 2:nk
-        push!(distances, distances[end] + norm(points[i] - points[i - 1]))
-    end
-
-    BandStructure{2}(points, distances, frequencies, Tuple{Int,String}[])
-end
-
-"""
-    compute_bands(solver::Solver, kpi::KPathInterpolant; bands=1:10, verbose=false)
-
-Compute band structure using Brillouin.jl KPathInterpolant.
-"""
-function compute_bands(
-    solver::Solver{Dim2}, kpi::KPathInterpolant; bands=1:10, verbose::Bool=false
-)
-    # Extract k-points from interpolant (only kx, ky for 2D)
-    kpoints_3d = collect(kpi)
-    kpoints = [SVector{2}(k[1], k[2]) for k in kpoints_3d]
-
-    nk = length(kpoints)
-    nbands = length(bands)
-    frequencies = zeros(Float64, nk, nbands)
-
-    for (ik, k) in enumerate(kpoints)
-        if verbose && ik % 10 == 0
-            println("Computing k-point $ik / $nk")
-        end
-        ω, _ = solve(solver, collect(k); bands=bands)
-        frequencies[ik, :] = ω
-    end
-
-    # Compute distances
-    distances = Float64[0.0]
-    for i in 2:nk
-        push!(distances, distances[end] + norm(kpoints[i] - kpoints[i - 1]))
-    end
-
-    # Extract labels from KPathInterpolant if available
-    labels = Tuple{Int,String}[]
-
-    BandStructure{2}(kpoints, distances, frequencies, labels)
-end
+# Note: compute_bands functions with track_bands option are defined below
+# after the Band Sorting section
 
 # ============================================================================
 # 3D Band structure computation
 # ============================================================================
 
-"""
-    compute_bands(solver::Solver{Dim3}, kpath::SimpleKPath{3}; bands=1:10, verbose=false)
-
-Compute 3D band structure along a k-point path.
-
-# Arguments
-- `solver`: 3D solver (FullVectorEM or FullElastic)
-- `kpath`: K-point path from `simple_kpath_cubic`, `simple_kpath_fcc`, etc.
-- `bands`: Which bands to compute (default: 1:10)
-- `verbose`: Print progress (default: false)
-
-# Returns
-A `BandStructure{3}` object containing frequencies for each k-point and band.
-
-# Example
-```julia
-lat = fcc_lattice(1.0)
-geo = Geometry(lat, Dielectric(1.0), [(Sphere([0,0,0], 0.25), Dielectric(12.0))])
-solver = Solver(FullVectorEM(), geo, (12,12,12), KrylovKitMethod(shift=0.01); cutoff=3)
-kpath = simple_kpath_fcc(a=1.0, npoints=20)
-bands = compute_bands(solver, kpath; bands=1:6)
-```
-
-# Note
-At Γ point (k=0), the lowest transverse modes also have ω→0, which can cause
-anomalous values. Consider using a small k offset or skipping the Γ point.
-"""
-function compute_bands(
-    solver::Solver{Dim3}, kpath::SimpleKPath{3}; bands=1:10, verbose::Bool=false
-)
-    nk = length(kpath)
-    nbands = length(bands)
-    frequencies = zeros(Float64, nk, nbands)
-
-    for (ik, k) in enumerate(kpath.points)
-        if verbose && ik % 10 == 0
-            println("Computing k-point $ik / $nk")
-        end
-        ω, _ = solve(solver, collect(k); bands=bands)
-        frequencies[ik, :] = ω
-    end
-
-    BandStructure{3}(kpath.points, kpath.distances, frequencies, kpath.labels)
-end
-
-"""
-    compute_bands(solver::Solver{Dim3}, kpoints::Vector; bands=1:10, verbose=false)
-
-Compute 3D band structure at specified k-points (without path structure).
-
-# Arguments
-- `solver`: 3D solver (FullVectorEM or FullElastic)
-- `kpoints`: Vector of k-points as 3-element vectors
-- `bands`: Which bands to compute (default: 1:10)
-- `verbose`: Print progress (default: false)
-
-# Returns
-A `BandStructure{3}` object. Labels will be empty since no path structure is provided.
-
-# Example
-```julia
-kpoints = [[0.5, 0.0, 0.0], [0.5, 0.5, 0.0], [0.5, 0.5, 0.5]]
-bands = compute_bands(solver, kpoints; bands=1:6)
-```
-"""
-function compute_bands(
-    solver::Solver{Dim3}, kpoints::Vector{<:AbstractVector}; bands=1:10, verbose::Bool=false
-)
-    nk = length(kpoints)
-    nbands = length(bands)
-    frequencies = zeros(Float64, nk, nbands)
-
-    for (ik, k) in enumerate(kpoints)
-        if verbose && ik % 10 == 0
-            println("Computing k-point $ik / $nk")
-        end
-        ω, _ = solve(solver, collect(k); bands=bands)
-        frequencies[ik, :] = ω
-    end
-
-    # Create simple distance array
-    points = [SVector{3}(k...) for k in kpoints]
-    distances = Float64[0.0]
-    for i in 2:nk
-        push!(distances, distances[end] + norm(points[i] - points[i - 1]))
-    end
-
-    BandStructure{3}(points, distances, frequencies, Tuple{Int,String}[])
-end
-
-"""
-    compute_bands(solver::Solver{Dim3}, kpi::KPathInterpolant; bands=1:10, verbose=false)
-
-Compute 3D band structure using Brillouin.jl KPathInterpolant.
-
-# Arguments
-- `solver`: 3D solver (FullVectorEM or FullElastic)
-- `kpi`: K-path interpolant from `kpath_cubic`, `kpath_fcc`, `kpath_bcc`, etc.
-- `bands`: Which bands to compute (default: 1:10)
-- `verbose`: Print progress (default: false)
-
-# Returns
-A `BandStructure{3}` object.
-
-# Example
-```julia
-lat = cubic_lattice(1.0)
-geo = Geometry(lat, Dielectric(1.0), [(Sphere([0,0,0], 0.3), Dielectric(12.0))])
-solver = Solver(FullVectorEM(), geo, (12,12,12), KrylovKitMethod(shift=0.01); cutoff=3)
-kpath = kpath_cubic(a=1.0, N=50)  # Brillouin.jl based
-bands = compute_bands(solver, kpath; bands=1:6)
-```
-"""
-function compute_bands(
-    solver::Solver{Dim3}, kpi::KPathInterpolant; bands=1:10, verbose::Bool=false
-)
-    kpoints_raw = collect(kpi)
-    kpoints = [SVector{3}(k[1], k[2], k[3]) for k in kpoints_raw]
-
-    nk = length(kpoints)
-    nbands = length(bands)
-    frequencies = zeros(Float64, nk, nbands)
-
-    for (ik, k) in enumerate(kpoints)
-        if verbose && ik % 10 == 0
-            println("Computing k-point $ik / $nk")
-        end
-        ω, _ = solve(solver, collect(k); bands=bands)
-        frequencies[ik, :] = ω
-    end
-
-    # Compute distances
-    distances = Float64[0.0]
-    for i in 2:nk
-        push!(distances, distances[end] + norm(kpoints[i] - kpoints[i - 1]))
-    end
-
-    # Extract labels from KPathInterpolant if available
-    labels = Tuple{Int,String}[]
-
-    BandStructure{3}(kpoints, distances, frequencies, labels)
-end
+# Note: 3D compute_bands functions with track_bands option are defined below
+# after the Band Sorting section
 
 # ============================================================================
 # Analysis functions
@@ -410,6 +164,342 @@ function _compute_bands_warmstart!(
             prev_eigenvectors = vecs
         end
     end
+end
+
+# ============================================================================
+# Band Sorting (Track bands across k-points)
+# ============================================================================
+
+"""
+    find_best_permutation(overlap_sq::AbstractMatrix{<:Real}) -> Vector{Int}
+
+Find permutation that maximizes sum of diagonal elements.
+
+Uses greedy algorithm (O(n²)) which works well for band tracking.
+Given a matrix of squared overlaps |⟨ψᵢ|ψⱼ⟩|², finds the permutation
+that assigns each previous band to the current band with maximum overlap.
+
+# Arguments
+- `overlap_sq`: Matrix of squared overlaps (n_bands × n_bands)
+
+# Returns
+- `perm`: Permutation vector where perm[i] is the new index for band i
+"""
+function find_best_permutation(overlap_sq::AbstractMatrix{<:Real})
+    n = size(overlap_sq, 1)
+    perm = zeros(Int, n)
+    used = falses(n)
+
+    for i in 1:n
+        # Find best unused column for row i
+        best_j = 0
+        best_val = -Inf
+        for j in 1:n
+            if !used[j] && overlap_sq[i, j] > best_val
+                best_val = overlap_sq[i, j]
+                best_j = j
+            end
+        end
+        perm[i] = best_j
+        used[best_j] = true
+    end
+
+    return perm
+end
+
+"""
+    _track_bands!(frequencies, kpoints, solver, bands, verbose)
+
+Internal helper for band tracking using eigenvector overlap.
+
+Reorders eigenvalues at each k-point to maintain band continuity
+by tracking eigenvector overlaps between adjacent k-points.
+"""
+function _track_bands!(
+    frequencies::Matrix{Float64},
+    kpoints,
+    solver::Solver,
+    bands,
+    verbose::Bool
+)
+    nk = length(kpoints)
+    nbands = length(bands)
+
+    # Get weight matrix for inner product
+    W = get_weight_matrix(solver)
+
+    # First k-point
+    k = collect(kpoints[1])
+    ω, vecs = solve_at_k_with_vectors(solver, k, solver.method; bands=bands)
+    frequencies[1, :] = ω
+    prev_vecs = vecs
+
+    # Track bands through remaining k-points
+    for ik in 2:nk
+        if verbose && ik % 10 == 0
+            println("Computing k-point $ik / $nk (tracking)")
+        end
+
+        k = collect(kpoints[ik])
+        ω, vecs = solve_at_k_with_vectors(solver, k, solver.method; bands=bands)
+
+        # Compute overlap matrix: M[i,j] = |⟨prev_i|current_j⟩|²
+        M = overlap_matrix(prev_vecs, vecs, W)
+        overlap_sq = abs2.(M)
+
+        # Find best permutation
+        perm = find_best_permutation(overlap_sq)
+
+        # Apply permutation
+        frequencies[ik, :] = ω[perm]
+        prev_vecs = vecs[:, perm]
+    end
+end
+
+# ============================================================================
+# Tracked band computation (2D)
+# ============================================================================
+
+"""
+    compute_bands(solver::Solver, kpath; bands=1:10, verbose=false, track_bands=false)
+
+Compute band structure along a k-point path.
+
+When the solver uses LOBPCGMethod with warm_start=true, automatically:
+1. Solves first k-point with Dense (if first_dense=true)
+2. Uses previous eigenvectors as initial guess for subsequent k-points
+3. Applies matrix scaling (if scale=true)
+
+This can achieve up to 38x speedup for large problems.
+
+# Arguments
+- `solver`: The solver
+- `kpath`: K-point path (SimpleKPath, KPathInterpolant, or Vector)
+- `bands`: Which bands to compute (default: 1:10)
+- `verbose`: Print progress (default: false)
+- `track_bands`: Track bands across k-points using eigenvector overlap (default: false).
+  When true, bands are reordered at each k-point to maintain continuity,
+  preventing spurious crossings from appearing as discontinuities.
+
+# Returns
+A `BandStructure` object containing frequencies for each k-point and band.
+"""
+function compute_bands(
+    solver::Solver{Dim2}, kpath::SimpleKPath{2}; bands=1:10, verbose::Bool=false,
+    track_bands::Bool=false
+)
+    nk = length(kpath)
+    nbands = length(bands)
+    frequencies = zeros(Float64, nk, nbands)
+
+    if track_bands
+        _track_bands!(frequencies, kpath.points, solver, bands, verbose)
+    else
+        # Check if warm start is enabled
+        method = solver.method
+        use_warm_start = method isa LOBPCGMethod && method.warm_start
+
+        if use_warm_start
+            _compute_bands_warmstart!(frequencies, solver, kpath.points, bands, verbose)
+        else
+            for (ik, k) in enumerate(kpath.points)
+                if verbose && ik % 10 == 0
+                    println("Computing k-point $ik / $nk")
+                end
+                ω, _ = solve(solver, collect(k); bands=bands)
+                frequencies[ik, :] = ω
+            end
+        end
+    end
+
+    BandStructure{2}(kpath.points, kpath.distances, frequencies, kpath.labels)
+end
+
+function compute_bands(
+    solver::Solver{Dim2}, kpoints::Vector{<:AbstractVector}; bands=1:10, verbose::Bool=false,
+    track_bands::Bool=false
+)
+    nk = length(kpoints)
+    nbands = length(bands)
+    frequencies = zeros(Float64, nk, nbands)
+
+    if track_bands
+        _track_bands!(frequencies, kpoints, solver, bands, verbose)
+    else
+        for (ik, k) in enumerate(kpoints)
+            if verbose && ik % 10 == 0
+                println("Computing k-point $ik / $nk")
+            end
+            ω, _ = solve(solver, k; bands=bands)
+            frequencies[ik, :] = ω
+        end
+    end
+
+    # Create simple distance array
+    points = [SVector{2}(k...) for k in kpoints]
+    distances = Float64[0.0]
+    for i in 2:nk
+        push!(distances, distances[end] + norm(points[i] - points[i - 1]))
+    end
+
+    BandStructure{2}(points, distances, frequencies, Tuple{Int,String}[])
+end
+
+function compute_bands(
+    solver::Solver{Dim2}, kpi::KPathInterpolant; bands=1:10, verbose::Bool=false,
+    track_bands::Bool=false
+)
+    # Extract k-points from interpolant (only kx, ky for 2D)
+    kpoints_3d = collect(kpi)
+    kpoints = [SVector{2}(k[1], k[2]) for k in kpoints_3d]
+
+    nk = length(kpoints)
+    nbands = length(bands)
+    frequencies = zeros(Float64, nk, nbands)
+
+    if track_bands
+        _track_bands!(frequencies, kpoints, solver, bands, verbose)
+    else
+        for (ik, k) in enumerate(kpoints)
+            if verbose && ik % 10 == 0
+                println("Computing k-point $ik / $nk")
+            end
+            ω, _ = solve(solver, collect(k); bands=bands)
+            frequencies[ik, :] = ω
+        end
+    end
+
+    # Compute distances
+    distances = Float64[0.0]
+    for i in 2:nk
+        push!(distances, distances[end] + norm(kpoints[i] - kpoints[i - 1]))
+    end
+
+    # Extract labels from KPathInterpolant if available
+    labels = Tuple{Int,String}[]
+
+    BandStructure{2}(kpoints, distances, frequencies, labels)
+end
+
+# ============================================================================
+# Tracked band computation (3D)
+# ============================================================================
+
+"""
+    compute_bands(solver::Solver{Dim3}, kpath::SimpleKPath{3}; bands=1:10, verbose=false, track_bands=false)
+
+Compute 3D band structure along a k-point path.
+
+# Arguments
+- `solver`: 3D solver (FullVectorEM or FullElastic)
+- `kpath`: K-point path from `simple_kpath_cubic`, `simple_kpath_fcc`, etc.
+- `bands`: Which bands to compute (default: 1:10)
+- `verbose`: Print progress (default: false)
+- `track_bands`: Track bands across k-points using eigenvector overlap (default: false).
+  When true, bands are reordered at each k-point to maintain continuity.
+
+# Returns
+A `BandStructure{3}` object containing frequencies for each k-point and band.
+
+# Example
+```julia
+lat = fcc_lattice(1.0)
+geo = Geometry(lat, Dielectric(1.0), [(Sphere([0,0,0], 0.25), Dielectric(12.0))])
+solver = Solver(FullVectorEM(), geo, (12,12,12), KrylovKitMethod(shift=0.01); cutoff=3)
+kpath = simple_kpath_fcc(a=1.0, npoints=20)
+bands = compute_bands(solver, kpath; bands=1:6, track_bands=true)
+```
+
+# Note
+At Γ point (k=0), the lowest transverse modes also have ω→0, which can cause
+anomalous values. Consider using a small k offset or skipping the Γ point.
+"""
+function compute_bands(
+    solver::Solver{Dim3}, kpath::SimpleKPath{3}; bands=1:10, verbose::Bool=false,
+    track_bands::Bool=false
+)
+    nk = length(kpath)
+    nbands = length(bands)
+    frequencies = zeros(Float64, nk, nbands)
+
+    if track_bands
+        _track_bands!(frequencies, kpath.points, solver, bands, verbose)
+    else
+        for (ik, k) in enumerate(kpath.points)
+            if verbose && ik % 10 == 0
+                println("Computing k-point $ik / $nk")
+            end
+            ω, _ = solve(solver, collect(k); bands=bands)
+            frequencies[ik, :] = ω
+        end
+    end
+
+    BandStructure{3}(kpath.points, kpath.distances, frequencies, kpath.labels)
+end
+
+function compute_bands(
+    solver::Solver{Dim3}, kpoints::Vector{<:AbstractVector}; bands=1:10, verbose::Bool=false,
+    track_bands::Bool=false
+)
+    nk = length(kpoints)
+    nbands = length(bands)
+    frequencies = zeros(Float64, nk, nbands)
+
+    if track_bands
+        _track_bands!(frequencies, kpoints, solver, bands, verbose)
+    else
+        for (ik, k) in enumerate(kpoints)
+            if verbose && ik % 10 == 0
+                println("Computing k-point $ik / $nk")
+            end
+            ω, _ = solve(solver, collect(k); bands=bands)
+            frequencies[ik, :] = ω
+        end
+    end
+
+    # Create simple distance array
+    points = [SVector{3}(k...) for k in kpoints]
+    distances = Float64[0.0]
+    for i in 2:nk
+        push!(distances, distances[end] + norm(points[i] - points[i - 1]))
+    end
+
+    BandStructure{3}(points, distances, frequencies, Tuple{Int,String}[])
+end
+
+function compute_bands(
+    solver::Solver{Dim3}, kpi::KPathInterpolant; bands=1:10, verbose::Bool=false,
+    track_bands::Bool=false
+)
+    kpoints_raw = collect(kpi)
+    kpoints = [SVector{3}(k[1], k[2], k[3]) for k in kpoints_raw]
+
+    nk = length(kpoints)
+    nbands = length(bands)
+    frequencies = zeros(Float64, nk, nbands)
+
+    if track_bands
+        _track_bands!(frequencies, kpoints, solver, bands, verbose)
+    else
+        for (ik, k) in enumerate(kpoints)
+            if verbose && ik % 10 == 0
+                println("Computing k-point $ik / $nk")
+            end
+            ω, _ = solve(solver, collect(k); bands=bands)
+            frequencies[ik, :] = ω
+        end
+    end
+
+    # Compute distances
+    distances = Float64[0.0]
+    for i in 2:nk
+        push!(distances, distances[end] + norm(kpoints[i] - kpoints[i - 1]))
+    end
+
+    # Extract labels from KPathInterpolant if available
+    labels = Tuple{Int,String}[]
+
+    BandStructure{3}(kpoints, distances, frequencies, labels)
 end
 
 # ============================================================================

--- a/test/band_sorting_test.jl
+++ b/test/band_sorting_test.jl
@@ -1,0 +1,68 @@
+# Tests for band sorting functionality
+
+@testset "Band Sorting" begin
+
+    @testset "find_best_permutation" begin
+        # Identity case
+        M = [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]
+        @test PhoXonic.find_best_permutation(M) == [1, 2, 3]
+
+        # Permuted case
+        M = [0.0 1.0 0.0; 0.0 0.0 1.0; 1.0 0.0 0.0]
+        @test PhoXonic.find_best_permutation(M) == [2, 3, 1]
+
+        # Soft overlap (realistic case)
+        M = [0.9 0.1 0.0; 0.1 0.8 0.1; 0.0 0.1 0.9]
+        @test PhoXonic.find_best_permutation(M) == [1, 2, 3]
+
+        # Another permutation
+        M = [0.1 0.9 0.0; 0.9 0.1 0.0; 0.0 0.0 1.0]
+        @test PhoXonic.find_best_permutation(M) == [2, 1, 3]
+    end
+
+    @testset "compute_bands with track_bands (2D)" begin
+        # 2D TM with potential band crossing
+        lat = square_lattice(1.0)
+        geo = Geometry(lat, Dielectric(1.0), [
+            (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+        ])
+        solver = Solver(TMWave(), geo, (32, 32); cutoff=5)
+
+        # Simple k-path
+        kpath = simple_kpath_square(; npoints=11)
+
+        # Without tracking
+        bands_unsorted = compute_bands(solver, kpath; bands=1:5, track_bands=false)
+
+        # With tracking
+        bands_sorted = compute_bands(solver, kpath; bands=1:5, track_bands=true)
+
+        # Same frequencies at endpoints (Γ point)
+        @test bands_unsorted.frequencies[1, :] ≈ bands_sorted.frequencies[1, :]
+
+        # Sorted should be smoother (lower total variation)
+        function total_variation(freqs)
+            sum(abs.(diff(freqs, dims=1)))
+        end
+        @test total_variation(bands_sorted.frequencies) <= total_variation(bands_unsorted.frequencies) + 0.01
+    end
+
+    @testset "track_bands preserves eigenvalues" begin
+        # Ensure tracking doesn't change the set of eigenvalues, just their order
+        lat = square_lattice(1.0)
+        geo = Geometry(lat, Dielectric(1.0), [
+            (Circle([0.5, 0.5], 0.3), Dielectric(4.0))
+        ])
+        solver = Solver(TEWave(), geo, (24, 24); cutoff=4)
+
+        kpath = simple_kpath_square(; npoints=5)
+
+        bands_unsorted = compute_bands(solver, kpath; bands=1:4, track_bands=false)
+        bands_sorted = compute_bands(solver, kpath; bands=1:4, track_bands=true)
+
+        # At each k-point, the set of frequencies should be the same (just reordered)
+        for ik in 1:5
+            @test sort(bands_unsorted.frequencies[ik, :]) ≈ sort(bands_sorted.frequencies[ik, :])
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2006,4 +2006,7 @@ using LinearAlgebra
 
     # Wilson loop and topological invariants
     include("wilson_test.jl")
+
+    # Band sorting
+    include("band_sorting_test.jl")
 end


### PR DESCRIPTION
## Summary
- Add `track_bands` option to `compute_bands` for band continuity via eigenvector overlap
- Add DOS/LDOS examples (502, 503, 504) and 3D FCC phononic example (403)
- Add band tracking documentation (`docs/src/analysis.md`)

Closes #24

## Changes
- `src/bandstructure.jl`: `find_best_permutation`, `_track_bands!`, `track_bands` kwarg
- `test/band_sorting_test.jl`: unit + integration tests
- `examples/403_fcc_phononic.jl`: 3D FCC WC/Epoxy with `track_bands=true`
- `examples/502_dos.jl`: 2D photonic DOS (DirectGF)
- `examples/503_ldos_rsk.jl`: LDOS at defect site (MatrixFreeGF)
- `examples/504_dos_1d.jl`: 1D photonic DOS + band structure

## Test plan
- [ ] `Pkg.test()` passes (1,564 tests, band_sorting_test.jl included)
- [ ] Example 502 runs and produces DOS plot
- [ ] Example 504 runs and produces 1D DOS plot