### PR TITLE
Add field visualization

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(;
         "3D Calculations" => "workflow_3d.md",
         "Solver Methods" => "solver.md",
         "Analysis" => "analysis.md",
+        "Field Visualization" => "field_visualization.md",
         "DOS / LDOS" => "greens_function.md",
         "Topological Invariants" => "topology.md",
         "Examples" => "examples.md",

--- a/docs/src/api-advanced.md
+++ b/docs/src/api-advanced.md
@@ -26,6 +26,28 @@ The `track_bands` option in [`compute_bands`](@ref) uses eigenvector overlap to 
 
 See [Band Tracking](analysis.md#Band-Tracking) for usage examples.
 
+## Field Visualization
+
+See [Field Visualization](field_visualization.md) for usage examples.
+
+### Core Functions
+
+```@docs
+reconstruct_field
+get_epsilon_field
+get_material_field
+fix_phase
+field_energy
+```
+
+### Plotting Functions
+
+```@docs
+plot_field
+plot_epsilon
+plot_field!
+```
+
 ## Green's Function and DOS/LDOS
 
 !!! note "Optional Dependency"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -214,3 +214,6 @@ See the `examples/` directory in the repository for additional examples:
 | TMM | [`603_tmm_phononic.jl`](https://github.com/hsugawa8651/PhoXonic.jl/blob/main/examples/603_tmm_phononic.jl) | Phononic superlattice |
 | TMM | [`604_tmm_vs_pwe.jl`](https://github.com/hsugawa8651/PhoXonic.jl/blob/main/examples/604_tmm_vs_pwe.jl) | TMM vs PWE comparison |
 | Utility | [`801_plot_structures.jl`](https://github.com/hsugawa8651/PhoXonic.jl/blob/main/examples/801_plot_structures.jl) | Structure visualization |
+| Field Viz | [`811_field_1d.jl`](https://github.com/hsugawa8651/PhoXonic.jl/blob/main/examples/811_field_1d.jl) | 1D photonic field modes |
+| Field Viz | [`812_field_2d_tm.jl`](https://github.com/hsugawa8651/PhoXonic.jl/blob/main/examples/812_field_2d_tm.jl) | 2D TM photonic field |
+| Field Viz | [`813_field_2d_sh.jl`](https://github.com/hsugawa8651/PhoXonic.jl/blob/main/examples/813_field_2d_sh.jl) | 2D SH phononic field |

--- a/docs/src/field_visualization.md
+++ b/docs/src/field_visualization.md
@@ -1,0 +1,234 @@
+# Field Visualization
+
+This page describes how to visualize electromagnetic/acoustic fields in PhoXonic.jl.
+
+## Quick Start
+
+```julia
+using PhoXonic
+using Plots
+
+# Create geometry and solver
+lat = square_lattice(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+])
+solver = Solver(TMWave(), geo, (64, 64); cutoff=7)
+
+# Solve at k-point
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+
+# Visualize field
+plot_field(solver, vecs[:, 1])
+```
+
+## Core Functions
+
+### reconstruct_field
+
+Convert an eigenvector (plane wave coefficients) to a real-space field distribution.
+
+```julia
+# Basic usage
+field = reconstruct_field(solver, vecs[:, 1])
+
+# Custom output grid resolution
+field_hires = reconstruct_field(solver, vecs[:, 1]; grid=(128, 128))
+```
+
+The return type depends on the wave type:
+- **Scalar fields** (TEWave, TMWave, SHWave, Photonic1D, Longitudinal1D): Returns an array of dimension D
+- **Vector fields** (PSVWave, TransverseEM, FullElastic): Returns a tuple of arrays, one per component
+
+### get_epsilon_field
+
+Get the permittivity distribution on the real-space grid.
+
+```julia
+eps = get_epsilon_field(solver)
+```
+
+### get_material_field
+
+Get an arbitrary material property distribution.
+
+```julia
+# For phononic: get density
+rho = get_material_field(solver, :ρ)
+
+# For photonic: get permeability
+mu = get_material_field(solver, :μ)
+
+# Available properties depend on wave type:
+# - Photonic: :ε, :μ, :ε_inv, :μ_inv
+# - Phononic: :ρ, :C11, :C12, :C44
+```
+
+### fix_phase
+
+Normalize the global phase of a complex field for visualization.
+
+```julia
+field_fixed = fix_phase(field; method=:max)
+```
+
+Available methods:
+- `:max` (default): Make the maximum amplitude point real and positive
+- `:center`: Make the center point real and positive
+- `:mean`: Rotate to minimize imaginary part (mean phase = 0)
+
+After calling `fix_phase`, plotting `real(field)` gives meaningful results.
+
+### field_energy
+
+Compute the energy density of a mode.
+
+```julia
+energy = field_energy(solver, vecs[:, 1])
+```
+
+Returns the energy density on the real-space grid (always real, non-negative):
+- For photonic modes: proportional to |H|² (or |E|² for TM)
+- For phononic modes: proportional to ρ|u|²
+
+## Plotting Functions
+
+### plot_field
+
+Visualize a field distribution. Requires Plots.jl.
+
+**1D fields:**
+```julia
+plot_field(solver, vecs[:, 1];
+    quantity=:real,      # :real, :imag, :abs, :phase
+    fix_phase_flag=true,
+    title="Field",
+    xlabel="x/a",
+    ylabel="Field"
+)
+```
+
+**2D fields:**
+```julia
+plot_field(solver, vecs[:, 1];
+    component=:auto,     # For vector fields: :auto, :x, :y, :z
+    quantity=:real,
+    colormap=:RdBu,
+    fix_phase_flag=true,
+    title="Field",
+    xlabel="x/a",
+    ylabel="y/a"
+)
+```
+
+### plot_epsilon
+
+Visualize the permittivity distribution.
+
+**1D:**
+```julia
+plot_epsilon(solver;
+    title="Permittivity",
+    xlabel="x/a",
+    ylabel="ε"
+)
+```
+
+**2D:**
+```julia
+plot_epsilon(solver;
+    colormap=:grays,
+    title="Permittivity",
+    xlabel="x/a",
+    ylabel="y/a"
+)
+```
+
+## Examples
+
+### Example 811: 1D Field Visualization
+
+```julia
+using PhoXonic
+using Plots
+
+# Create 1D photonic crystal
+lat = lattice_1d(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Segment(0.0, 0.3), Dielectric(9.0))
+])
+solver = Solver(Photonic1D(), geo, (128,); cutoff=10)
+
+# Solve at Gamma point
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0], DenseMethod())
+
+# Plot first 4 modes
+p = plot(layout=(2, 2), size=(800, 600))
+x = range(0, 1, length=128)
+eps = get_epsilon_field(solver)
+
+for i in 1:4
+    field = reconstruct_field(solver, vecs[:, i])
+    field_fixed = fix_phase(field)
+
+    plot!(p, x, real.(field_fixed);
+        subplot=i,
+        title="Band $i (ω = $(round(freqs[i], digits=3)))",
+        label="Field", linewidth=2
+    )
+    plot!(p, x, eps ./ 10;
+        subplot=i, label="ε/10", linestyle=:dash, alpha=0.5
+    )
+end
+```
+
+### Example 812: 2D TM Field Visualization
+
+```julia
+using PhoXonic
+using Plots
+
+# Create 2D photonic crystal
+lat = square_lattice(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+])
+solver = Solver(TMWave(), geo, (64, 64); cutoff=7)
+
+# Solve at Gamma point
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+
+# Visualize first mode
+field = reconstruct_field(solver, vecs[:, 1])
+field_fixed = fix_phase(field)
+heatmap(real.(field_fixed)'; c=:RdBu, aspect_ratio=:equal)
+```
+
+### Example 813: 2D SH Phononic Field Visualization
+
+```julia
+using PhoXonic
+using Plots
+
+# Create 2D phononic crystal: steel in epoxy
+lat = square_lattice(1.0)
+epoxy = IsotropicElastic(ρ=1180.0, λ=4.43e9, μ=1.59e9)
+steel = IsotropicElastic(ρ=7800.0, λ=115e9, μ=82e9)
+
+geo = Geometry(lat, epoxy, [
+    (Circle([0.5, 0.5], 0.3), steel)
+])
+solver = Solver(SHWave(), geo, (64, 64); cutoff=7)
+
+# Solve at Gamma point
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+
+# Visualize displacement field uz
+field = reconstruct_field(solver, vecs[:, 1])
+field_fixed = fix_phase(field)
+heatmap(real.(field_fixed)'; c=:RdBu, aspect_ratio=:equal)
+```
+
+## API Reference
+
+See [Advanced API - Field Visualization](api-advanced.md#Field-Visualization).

--- a/examples/000_examples.md
+++ b/examples/000_examples.md
@@ -100,11 +100,14 @@ automatically satisfies ∇·H = 0.
 | 702_wilson_loop_2d.jl | 2D Wilson loop spectrum |
 | 703_wilson_fragile.jl | Wilson loop for de Paz 2019 (fragile topology) |
 
-### 8xx: Utilities
+### 8xx: Utilities / Field Visualization
 
 | File | Description |
 |------|-------------|
 | 801_plot_structures.jl | Structure plot generation |
+| 811_field_1d.jl | 1D photonic field visualization |
+| 812_field_2d_tm.jl | 2D TM photonic field visualization |
+| 813_field_2d_sh.jl | 2D SH phononic field visualization |
 
 ### 9xx: Benchmarks / References
 

--- a/examples/702_wilson_loop_2d.jl
+++ b/examples/702_wilson_loop_2d.jl
@@ -89,7 +89,7 @@ println("Saved: 702_wilson_loop_2d.png")
 println()
 println("Computing band structure...")
 
-kpath = kpath_square()
+kpath = simple_kpath_square(; npoints = 31)
 bands = compute_bands(solver, kpath; bands = 1:6)
 
 # Manual plot with clear axis labels

--- a/examples/811_field_1d.jl
+++ b/examples/811_field_1d.jl
@@ -1,0 +1,65 @@
+# Example 811: 1D Field Visualization
+#
+# Demonstrates field reconstruction and visualization for 1D photonic crystals.
+# Output: 811_field_1d.png
+
+using PhoXonic
+using Plots
+
+println("Example 811: 1D Field Visualization")
+println("=" ^ 50)
+
+# Create 1D photonic crystal: air + dielectric slab
+lat = lattice_1d(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Segment(0.0, 0.3), Dielectric(9.0))  # 30% filling fraction
+])
+
+# Create solver
+solver = Solver(Photonic1D(), geo, (128,); cutoff=10)
+println("Resolution: 128, Cutoff: 10")
+println("Number of plane waves: $(solver.basis.num_pw)")
+
+# Solve at Gamma point (k = 0)
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0], DenseMethod())
+println("\nFirst 4 frequencies: ", round.(freqs[1:4], digits=4))
+
+# Create multi-panel plot
+p = plot(layout=(2, 2), size=(1000, 800),
+    tickfontsize=12, guidefontsize=14, titlefontsize=14,
+    left_margin=5Plots.mm, bottom_margin=5Plots.mm, top_margin=-2Plots.mm,
+    legend=:topright)
+
+# Get epsilon for reference
+eps = get_epsilon_field(solver)
+x = range(0, 1, length=128)
+
+# Plot first 4 modes
+for i in 1:4
+    field = reconstruct_field(solver, vecs[:, i])
+    field_fixed = fix_phase(field)
+
+    plot!(p, x, real.(field_fixed);
+        subplot=i,
+        title="Band $i (ω = $(round(freqs[i], digits=3)))",
+        xlabel="x/a",
+        ylabel="Field",
+        label="Field",
+        linewidth=2
+    )
+
+    # Overlay scaled epsilon as filled area
+    eps_scaled = eps ./ maximum(eps) .* maximum(abs.(field_fixed)) .* 0.3
+    plot!(p, x, eps_scaled;
+        subplot=i,
+        label="ε (scaled)",
+        fillrange=0,
+        fillalpha=0.3,
+        fillcolor=:orange,
+        linecolor=:orange,
+        alpha=0.5
+    )
+end
+
+savefig(p, "811_field_1d.png")
+println("\nSaved: 811_field_1d.png")

--- a/examples/812_field_2d_tm.jl
+++ b/examples/812_field_2d_tm.jl
@@ -1,0 +1,60 @@
+# Example 812: 2D TM Field Visualization
+#
+# Demonstrates field reconstruction for 2D TM modes (Ez field).
+# Output: 812_field_2d_tm.png
+
+using PhoXonic
+using Plots
+
+println("Example 812: 2D TM Field Visualization")
+println("=" ^ 50)
+
+# Create 2D photonic crystal: square lattice with dielectric rods
+lat = square_lattice(1.0)
+geo = Geometry(lat, Dielectric(1.0), [
+    (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+])
+
+# Create solver
+solver = Solver(TMWave(), geo, (128, 128); cutoff=7)
+println("Resolution: 128x128, Cutoff: 7")
+println("Number of plane waves: $(solver.basis.num_pw)")
+
+# Solve at Gamma point
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+println("\nFirst 5 frequencies: ", round.(freqs[1:5], digits=4))
+
+# Create 2x3 panel plot
+p = plot(layout=(2, 3), size=(1200, 800),
+    tickfontsize=12, guidefontsize=14, titlefontsize=14,
+    bottom_margin=5Plots.mm, top_margin=-2Plots.mm)
+
+# Plot epsilon
+eps = get_epsilon_field(solver)
+heatmap!(p, eps';
+    subplot=1,
+    c=:grays,
+    title="ε(x,y)",
+    aspect_ratio=:equal
+)
+
+# Plot first 5 bands
+for i in 1:5
+    field = reconstruct_field(solver, vecs[:, i])
+    field_fixed = fix_phase(field)
+    data = real.(field_fixed)
+
+    # Symmetric colormap
+    maxval = maximum(abs.(data))
+
+    heatmap!(p, data';
+        subplot=i+1,
+        c=:RdBu,
+        clims=(-maxval, maxval),
+        title="Band $i (ω = $(round(freqs[i], digits=3)))",
+        aspect_ratio=:equal
+    )
+end
+
+savefig(p, "812_field_2d_tm.png")
+println("\nSaved: 812_field_2d_tm.png")

--- a/examples/813_field_2d_sh.jl
+++ b/examples/813_field_2d_sh.jl
@@ -1,0 +1,65 @@
+# Example 813: 2D SH Phononic Field Visualization
+#
+# Demonstrates field reconstruction for 2D SH (shear horizontal) phononic modes.
+# Output: 813_field_2d_sh.png
+
+using PhoXonic
+using Plots
+
+println("Example 813: 2D SH Phononic Field Visualization")
+println("=" ^ 50)
+
+# Create 2D phononic crystal: square lattice with steel cylinders in epoxy
+lat = square_lattice(1.0)
+
+# Materials: epoxy matrix with steel inclusions
+epoxy = IsotropicElastic(ρ=1180.0, λ=4.43e9, μ=1.59e9)
+steel = IsotropicElastic(ρ=7800.0, λ=115e9, μ=82e9)
+
+geo = Geometry(lat, epoxy, [
+    (Circle([0.5, 0.5], 0.3), steel)  # r/a = 0.3
+])
+
+# Create solver
+solver = Solver(SHWave(), geo, (128, 128); cutoff=7)
+println("Resolution: 128x128, Cutoff: 7")
+println("Number of plane waves: $(solver.basis.num_pw)")
+
+# Solve at Gamma point
+freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+println("\nFirst 5 frequencies (rad/s): ", round.(freqs[1:5], digits=1))
+
+# Create 2x3 panel plot
+p = plot(layout=(2, 3), size=(1200, 800),
+    tickfontsize=12, guidefontsize=14, titlefontsize=14,
+    bottom_margin=5Plots.mm, top_margin=-2Plots.mm, right_margin=5Plots.mm)
+
+# Plot density distribution
+rho = get_material_field(solver, :ρ)
+heatmap!(p, rho';
+    subplot=1,
+    c=:viridis,
+    title="ρ(x,y) [kg/m³]",
+    aspect_ratio=:equal
+)
+
+# Plot first 5 bands (displacement field uz)
+for i in 1:5
+    field = reconstruct_field(solver, vecs[:, i])
+    field_fixed = fix_phase(field)
+    data = real.(field_fixed)
+
+    # Symmetric colormap
+    maxval = maximum(abs.(data))
+
+    heatmap!(p, data';
+        subplot=i+1,
+        c=:RdBu,
+        clims=(-maxval, maxval),
+        title="Band $i (ω = $(round(freqs[i], digits=1)))",
+        aspect_ratio=:equal
+    )
+end
+
+savefig(p, "813_field_2d_sh.png")
+println("\nSaved: 813_field_2d_sh.png")

--- a/ext/PhoXonicPlotsExt.jl
+++ b/ext/PhoXonicPlotsExt.jl
@@ -10,6 +10,9 @@ using PhoXonic
 using Plots
 
 import PhoXonic: plot_bands, plot_bands!, band_plot_data
+import PhoXonic: plot_field, plot_field!, plot_epsilon
+import PhoXonic: reconstruct_field, get_epsilon_field, fix_phase
+import PhoXonic: Dim1, Dim2, Dim3, Solver, WaveType
 
 """
     plot_bands(bs::BandStructure; kwargs...)
@@ -171,6 +174,251 @@ function PhoXonic.plot_bands!(
     end
 
     return p
+end
+
+# =============================================================================
+# Field Visualization Functions
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# plot_field - 1D
+# -----------------------------------------------------------------------------
+"""
+    plot_field(solver::Solver{Dim1}, eigenvector; kwargs...)
+
+Plot a 1D field distribution.
+
+# Keyword Arguments
+- `quantity::Symbol = :real` - Quantity to plot: `:real`, `:imag`, `:abs`, `:phase`
+- `fix_phase_flag::Bool = true` - Apply phase normalization
+- `title::String = "Field"` - Plot title
+- `xlabel::String = "x/a"` - X-axis label
+- `ylabel::String = "Field"` - Y-axis label
+"""
+function PhoXonic.plot_field(
+    solver::Solver{Dim1},
+    eigenvector::AbstractVector;
+    quantity::Symbol=:real,
+    fix_phase_flag::Bool=true,
+    title::String="Field",
+    xlabel::String="x/a",
+    ylabel::String="Field",
+    kwargs...
+)
+    field = reconstruct_field(solver, eigenvector)
+    if fix_phase_flag
+        field = fix_phase(field)
+    end
+
+    data = _extract_quantity(field, quantity)
+    N = length(data)
+    x = range(0, 1, length=N)
+
+    Plots.plot(x, data;
+        xlabel=xlabel,
+        ylabel=ylabel,
+        title=title,
+        legend=false,
+        kwargs...
+    )
+end
+
+# -----------------------------------------------------------------------------
+# plot_field - 2D
+# -----------------------------------------------------------------------------
+"""
+    plot_field(solver::Solver{Dim2}, eigenvector; kwargs...)
+
+Plot a 2D field distribution as a heatmap.
+
+# Keyword Arguments
+- `component::Symbol = :auto` - Component to plot for vector fields
+- `quantity::Symbol = :real` - Quantity to plot: `:real`, `:imag`, `:abs`, `:phase`
+- `fix_phase_flag::Bool = true` - Apply phase normalization
+- `colormap::Symbol = :RdBu` - Colormap
+- `title::String = "Field"` - Plot title
+- `xlabel::String = "x/a"` - X-axis label
+- `ylabel::String = "y/a"` - Y-axis label
+"""
+function PhoXonic.plot_field(
+    solver::Solver{Dim2,W},
+    eigenvector::AbstractVector;
+    component::Symbol=:auto,
+    quantity::Symbol=:real,
+    fix_phase_flag::Bool=true,
+    colormap::Symbol=:RdBu,
+    title::String="Field",
+    xlabel::String="x/a",
+    ylabel::String="y/a",
+    kwargs...
+) where {W}
+    field = reconstruct_field(solver, eigenvector)
+
+    # Handle tuple (vector field) or matrix (scalar field)
+    if field isa Tuple
+        comp_idx = _get_component_index(W, component)
+        data_complex = field[comp_idx]
+    else
+        data_complex = field
+    end
+
+    if fix_phase_flag
+        data_complex = fix_phase(data_complex)
+    end
+
+    data = _extract_quantity(data_complex, quantity)
+
+    # Transpose for correct orientation (x horizontal, y vertical)
+    Plots.heatmap(data';
+        c=colormap,
+        title=title,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        aspect_ratio=:equal,
+        kwargs...
+    )
+end
+
+# -----------------------------------------------------------------------------
+# plot_field! - Add field to existing plot
+# -----------------------------------------------------------------------------
+"""
+    plot_field!(p, solver, eigenvector; kwargs...)
+
+Add a field to an existing plot.
+"""
+function PhoXonic.plot_field!(
+    p,
+    solver::Solver{Dim1},
+    eigenvector::AbstractVector;
+    quantity::Symbol=:real,
+    fix_phase_flag::Bool=true,
+    kwargs...
+)
+    field = reconstruct_field(solver, eigenvector)
+    if fix_phase_flag
+        field = fix_phase(field)
+    end
+
+    data = _extract_quantity(field, quantity)
+    N = length(data)
+    x = range(0, 1, length=N)
+
+    plot!(p, x, data; kwargs...)
+    return p
+end
+
+function PhoXonic.plot_field!(
+    p,
+    solver::Solver{Dim2,W},
+    eigenvector::AbstractVector;
+    component::Symbol=:auto,
+    quantity::Symbol=:real,
+    fix_phase_flag::Bool=true,
+    colormap::Symbol=:RdBu,
+    kwargs...
+) where {W}
+    field = reconstruct_field(solver, eigenvector)
+
+    if field isa Tuple
+        comp_idx = _get_component_index(W, component)
+        data_complex = field[comp_idx]
+    else
+        data_complex = field
+    end
+
+    if fix_phase_flag
+        data_complex = fix_phase(data_complex)
+    end
+
+    data = _extract_quantity(data_complex, quantity)
+
+    heatmap!(p, data'; c=colormap, aspect_ratio=:equal, kwargs...)
+    return p
+end
+
+# -----------------------------------------------------------------------------
+# plot_epsilon - 1D
+# -----------------------------------------------------------------------------
+"""
+    plot_epsilon(solver::Solver{Dim1}; kwargs...)
+
+Plot 1D permittivity distribution.
+"""
+function PhoXonic.plot_epsilon(
+    solver::Solver{Dim1};
+    title::String="Permittivity",
+    xlabel::String="x/a",
+    ylabel::String="ε",
+    kwargs...
+)
+    eps = get_epsilon_field(solver)
+    N = length(eps)
+    x = range(0, 1, length=N)
+
+    Plots.plot(x, eps;
+        xlabel=xlabel,
+        ylabel=ylabel,
+        title=title,
+        fill=0,
+        alpha=0.3,
+        legend=false,
+        kwargs...
+    )
+end
+
+# -----------------------------------------------------------------------------
+# plot_epsilon - 2D
+# -----------------------------------------------------------------------------
+"""
+    plot_epsilon(solver::Solver{Dim2}; kwargs...)
+
+Plot 2D permittivity distribution as a heatmap.
+"""
+function PhoXonic.plot_epsilon(
+    solver::Solver{Dim2};
+    colormap::Symbol=:grays,
+    title::String="Permittivity",
+    xlabel::String="x/a",
+    ylabel::String="y/a",
+    kwargs...
+)
+    eps = get_epsilon_field(solver)
+
+    Plots.heatmap(eps';
+        c=colormap,
+        title=title,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        aspect_ratio=:equal,
+        kwargs...
+    )
+end
+
+# -----------------------------------------------------------------------------
+# Helper functions for field visualization
+# -----------------------------------------------------------------------------
+function _extract_quantity(field::AbstractArray{<:Complex}, quantity::Symbol)
+    if quantity == :real
+        real.(field)
+    elseif quantity == :imag
+        imag.(field)
+    elseif quantity == :abs
+        abs.(field)
+    elseif quantity == :phase
+        angle.(field)
+    else
+        error("Unknown quantity: $quantity. Use :real, :imag, :abs, or :phase")
+    end
+end
+
+function _get_component_index(::Type{<:WaveType}, component::Symbol)
+    # Default: first component
+    component == :auto && return 1
+    component in (:x, :first, :1) && return 1
+    component in (:y, :second, :2) && return 2
+    component in (:z, :third, :3) && return 3
+    error("Unknown component: $component")
 end
 
 end # module

--- a/src/PhoXonic.jl
+++ b/src/PhoXonic.jl
@@ -42,6 +42,7 @@ include("waves.jl")
 # Solvers
 include("solver.jl")
 include("matrixfree.jl")
+include("field.jl")  # Field reconstruction (depends on matrixfree.jl)
 include("rscg.jl")
 
 # High-level API
@@ -106,6 +107,11 @@ export group_velocity, matrix_dimension
 export FFTContext, MatrixFreeWorkspace
 export MatrixFreeOperator, apply_lhs!, apply_rhs!
 export to_linear_map_lhs, to_linear_map_rhs
+
+# Exports - Field reconstruction and visualization
+export reconstruct_field, get_epsilon_field, get_material_field
+export fix_phase, field_energy
+export plot_field, plot_epsilon, plot_field!
 
 # Exports - Green's function and DOS/LDOS
 export compute_greens_function, compute_dos, compute_ldos

--- a/src/field.jl
+++ b/src/field.jl
@@ -1,0 +1,331 @@
+# src/field.jl
+# Field reconstruction and visualization core functions for PhoXonic.jl
+
+#=
+This file provides functions to convert eigenvectors (plane wave coefficients)
+to real-space field distributions.
+
+Key functions:
+- reconstruct_field: Convert eigenvector to real-space field
+- get_epsilon_field: Get permittivity distribution
+- get_material_field: Get arbitrary material property distribution
+- fix_phase: Normalize field phase for visualization
+- field_energy: Compute energy density
+
+Dependencies:
+- Uses fourier_to_grid! from matrixfree.jl (must be included after matrixfree.jl)
+=#
+
+# =============================================================================
+# reconstruct_field - Main API
+# =============================================================================
+
+"""
+    reconstruct_field(solver, eigenvector; grid=nothing)
+
+Convert an eigenvector (plane wave coefficients) to a real-space field.
+
+# Arguments
+- `solver::Solver`: The solver object containing basis and resolution info
+- `eigenvector::AbstractVector`: Eigenvector from `solve_at_k_with_vectors`
+
+# Keyword Arguments
+- `grid::Union{Nothing, NTuple{D,Int}}`: Output grid size. If `nothing`, uses `solver.resolution`
+
+# Returns
+- For scalar fields (ncomponents=1): Array of dimension D
+- For vector fields (ncomponents>1): Tuple of arrays
+
+# Examples
+```julia
+freqs, vecs = solve_at_k_with_vectors(solver, k)
+field = reconstruct_field(solver, vecs[:, 1])
+
+# Custom grid size
+field_hires = reconstruct_field(solver, vecs[:, 1]; grid=(128, 128))
+```
+"""
+function reconstruct_field(
+    solver::Solver{D,W},
+    eigenvector::AbstractVector{<:Complex};
+    grid::Union{Nothing,NTuple{N,Int} where N}=nothing
+) where {D,W}
+    resolution = isnothing(grid) ? solver.resolution : grid
+    ncomp = ncomponents(solver.wave)
+
+    if ncomp == 1
+        return _reconstruct_scalar_field(solver, eigenvector, resolution)
+    else
+        return _reconstruct_vector_field(solver, eigenvector, resolution, ncomp)
+    end
+end
+
+# -----------------------------------------------------------------------------
+# 1D scalar field reconstruction
+# -----------------------------------------------------------------------------
+function _reconstruct_scalar_field(
+    solver::Solver{Dim1,W},
+    eigenvector::AbstractVector{<:Complex},
+    resolution::NTuple{1,Int}
+) where {W}
+    N = resolution[1]
+    grid = zeros(ComplexF64, N)
+    fourier_to_grid!(grid, ComplexF64.(eigenvector), solver.basis, resolution)
+    return grid
+end
+
+# -----------------------------------------------------------------------------
+# 2D scalar field reconstruction
+# -----------------------------------------------------------------------------
+function _reconstruct_scalar_field(
+    solver::Solver{Dim2,W},
+    eigenvector::AbstractVector{<:Complex},
+    resolution::NTuple{2,Int}
+) where {W}
+    Nx, Ny = resolution
+    grid = zeros(ComplexF64, Nx, Ny)
+    fourier_to_grid!(grid, ComplexF64.(eigenvector), solver.basis, resolution)
+    return grid
+end
+
+# -----------------------------------------------------------------------------
+# 3D scalar field reconstruction
+# -----------------------------------------------------------------------------
+function _reconstruct_scalar_field(
+    solver::Solver{Dim3,W},
+    eigenvector::AbstractVector{<:Complex},
+    resolution::NTuple{3,Int}
+) where {W}
+    Nx, Ny, Nz = resolution
+    grid = zeros(ComplexF64, Nx, Ny, Nz)
+    fourier_to_grid!(grid, ComplexF64.(eigenvector), solver.basis, resolution)
+    return grid
+end
+
+# -----------------------------------------------------------------------------
+# 2D vector field reconstruction (ncomponents > 1)
+# -----------------------------------------------------------------------------
+function _reconstruct_vector_field(
+    solver::Solver{Dim2,W},
+    eigenvector::AbstractVector{<:Complex},
+    resolution::NTuple{2,Int},
+    ncomp::Int
+) where {W}
+    npw = solver.basis.num_pw
+    @assert length(eigenvector) == ncomp * npw "Eigenvector length mismatch: expected $(ncomp * npw), got $(length(eigenvector))"
+
+    Nx, Ny = resolution
+    fields = ntuple(ncomp) do i
+        start_idx = (i - 1) * npw + 1
+        end_idx = i * npw
+        coeffs = ComplexF64.(eigenvector[start_idx:end_idx])
+        grid = zeros(ComplexF64, Nx, Ny)
+        fourier_to_grid!(grid, coeffs, solver.basis, resolution)
+        grid
+    end
+
+    return fields
+end
+
+# -----------------------------------------------------------------------------
+# 3D vector field reconstruction (ncomponents > 1)
+# -----------------------------------------------------------------------------
+function _reconstruct_vector_field(
+    solver::Solver{Dim3,W},
+    eigenvector::AbstractVector{<:Complex},
+    resolution::NTuple{3,Int},
+    ncomp::Int
+) where {W}
+    npw = solver.basis.num_pw
+    @assert length(eigenvector) == ncomp * npw "Eigenvector length mismatch"
+
+    Nx, Ny, Nz = resolution
+    fields = ntuple(ncomp) do i
+        start_idx = (i - 1) * npw + 1
+        end_idx = i * npw
+        coeffs = ComplexF64.(eigenvector[start_idx:end_idx])
+        grid = zeros(ComplexF64, Nx, Ny, Nz)
+        fourier_to_grid!(grid, coeffs, solver.basis, resolution)
+        grid
+    end
+
+    return fields
+end
+
+# =============================================================================
+# get_epsilon_field / get_material_field
+# =============================================================================
+
+"""
+    get_epsilon_field(solver)
+
+Get the permittivity distribution on the real-space grid.
+
+# Returns
+- 1D: `Vector{Float64}`
+- 2D: `Matrix{Float64}`
+- 3D: `Array{Float64,3}`
+
+# Examples
+```julia
+solver = Solver(TMWave(), geo, (64, 64); cutoff=7)
+eps = get_epsilon_field(solver)
+heatmap(eps)
+```
+"""
+function get_epsilon_field(solver::Solver)
+    mats = solver.material_arrays
+    if haskey(mats, :ε)
+        return copy(mats.ε)
+    elseif haskey(mats, :ε_inv)
+        # ε_inv only (TransverseEM, etc.)
+        return 1.0 ./ mats.ε_inv
+    else
+        error("Solver does not have epsilon data. This may be a phononic solver.")
+    end
+end
+
+"""
+    get_material_field(solver, property::Symbol)
+
+Get a material property distribution on the real-space grid.
+
+# Arguments
+- `property::Symbol`: One of `:ε`, `:μ`, `:ρ`, `:C11`, `:C12`, `:C44`
+
+# Examples
+```julia
+# Phononic: get density
+rho = get_material_field(solver, :ρ)
+
+# Photonic: get permeability
+mu = get_material_field(solver, :μ)
+```
+"""
+function get_material_field(solver::Solver, property::Symbol)
+    mats = solver.material_arrays
+    if haskey(mats, property)
+        return copy(getproperty(mats, property))
+    else
+        available = keys(mats)
+        error("Property :$property not available. Available: $available")
+    end
+end
+
+# =============================================================================
+# fix_phase
+# =============================================================================
+
+"""
+    fix_phase(field; method=:max)
+
+Normalize the phase of a complex field for visualization.
+
+After calling this function, plotting `real(field)` gives meaningful results.
+
+# Keyword Arguments
+- `method::Symbol`:
+  - `:max` - Make the maximum amplitude point real and positive (default)
+  - `:center` - Make the center point real and positive
+  - `:mean` - Rotate to minimize imaginary part (mean phase = 0)
+
+# Returns
+- Phase-normalized field (same type as input)
+
+# Examples
+```julia
+field = reconstruct_field(solver, vecs[:, 1])
+field_fixed = fix_phase(field)
+heatmap(real.(field_fixed))
+```
+"""
+function fix_phase(field::AbstractArray{<:Complex}; method::Symbol=:max)
+    if method == :max
+        # Find maximum amplitude point
+        idx = argmax(abs.(field))
+        phase = angle(field[idx])
+    elseif method == :center
+        # Center point
+        center_idx = div.(size(field) .+ 1, 2)
+        phase = angle(field[center_idx...])
+    elseif method == :mean
+        # Mean phase (without Statistics.mean dependency)
+        phase = angle(sum(field) / length(field))
+    else
+        error("Unknown method: $method. Use :max, :center, or :mean")
+    end
+
+    return field .* exp(-im * phase)
+end
+
+# =============================================================================
+# field_energy
+# =============================================================================
+
+"""
+    field_energy(solver, eigenvector)
+
+Compute the energy density of a mode.
+
+# Returns
+- Energy density on the real-space grid (always real, non-negative)
+
+For photonic modes: proportional to |H|² (or |E|² for TM)
+For phononic modes: proportional to ρ|u|²
+
+# Examples
+```julia
+energy = field_energy(solver, vecs[:, 1])
+heatmap(energy)
+```
+"""
+function field_energy(solver::Solver, eigenvector::AbstractVector{<:Complex})
+    field = reconstruct_field(solver, eigenvector)
+    return _compute_energy(field)
+end
+
+function _compute_energy(field::AbstractArray{<:Complex})
+    return abs2.(field)
+end
+
+function _compute_energy(fields::Tuple)
+    # Sum of |component|² for vector fields
+    return sum(abs2.(f) for f in fields)
+end
+
+# =============================================================================
+# Plot function stubs (implemented in Extensions)
+# =============================================================================
+
+"""
+    plot_field(solver, eigenvector; kwargs...)
+
+Visualize a field. Requires Plots.jl or Makie.jl.
+
+See `PhoXonicPlotsExt` or `PhoXonicMakieExt` for implementation.
+
+# Keyword Arguments
+- `component::Symbol = :auto` - Component to plot (for vector fields)
+- `quantity::Symbol = :real` - `:real`, `:imag`, `:abs`, `:phase`
+- `colormap::Symbol = :viridis` - Colormap
+- `title::String = "Field"` - Plot title
+
+For 3D fields:
+- `plane::Symbol = :xy` - Slice plane (`:xy`, `:yz`, `:xz`)
+- `slice::Real = 0.5` - Slice position (0 to 1)
+"""
+function plot_field end
+
+"""
+    plot_epsilon(solver; kwargs...)
+
+Visualize permittivity distribution. Requires Plots.jl or Makie.jl.
+"""
+function plot_epsilon end
+
+"""
+    plot_field!(fig, solver, eigenvector; kwargs...)
+
+Add field to existing figure.
+"""
+function plot_field! end

--- a/test/field_test.jl
+++ b/test/field_test.jl
@@ -1,0 +1,292 @@
+# test/field_test.jl
+# Field reconstruction tests for PhoXonic.jl
+
+using Test
+using PhoXonic
+using LinearAlgebra
+
+@testset "Field Reconstruction" begin
+
+    # =========================================================================
+    # Phase 1A-1: 1D scalar field
+    # =========================================================================
+    @testset "1D Photonic" begin
+        # Setup: 1D photonic crystal
+        lat = lattice_1d(1.0)
+        geo = Geometry(lat, Dielectric(1.0), [
+            (Segment(0.0, 0.3), Dielectric(9.0))
+        ])
+        solver = Solver(Photonic1D(), geo, (64,); cutoff=5)
+
+        # Solve at k = 0
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.0], DenseMethod())
+
+        @testset "reconstruct_field returns correct type and size" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test field isa Vector{ComplexF64}
+            @test length(field) == 64
+        end
+
+        @testset "reconstruct_field returns non-zero field" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test !all(iszero, field)
+            @test maximum(abs.(field)) > 0
+        end
+
+        @testset "custom grid size" begin
+            field = reconstruct_field(solver, vecs[:, 1]; grid=(128,))
+
+            @test length(field) == 128
+        end
+
+        @testset "multiple bands have different fields" begin
+            field1 = reconstruct_field(solver, vecs[:, 1])
+            field2 = reconstruct_field(solver, vecs[:, 2])
+
+            # Fields should be different (unless they are the same band)
+            @test !isapprox(field1, field2; rtol=0.1)
+        end
+    end
+
+    @testset "1D Longitudinal (Phononic)" begin
+        lat = lattice_1d(1.0)
+        geo = Geometry(lat, IsotropicElastic(ρ=1000.0, λ=1e9, μ=1e9), [
+            (Segment(0.0, 0.3), IsotropicElastic(ρ=2000.0, λ=2e9, μ=2e9))
+        ])
+        solver = Solver(Longitudinal1D(), geo, (64,); cutoff=5)
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.0], DenseMethod())
+
+        @testset "basic reconstruction" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test field isa Vector{ComplexF64}
+            @test length(field) == 64
+            @test !all(iszero, field)
+        end
+    end
+
+    # =========================================================================
+    # Phase 1A-2: 2D scalar field
+    # =========================================================================
+    @testset "2D TM (scalar)" begin
+        lat = square_lattice(1.0)
+        geo = Geometry(lat, Dielectric(1.0), [
+            (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+        ])
+        solver = Solver(TMWave(), geo, (32, 32); cutoff=5)
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+
+        @testset "reconstruct_field returns correct type and size" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test field isa Matrix{ComplexF64}
+            @test size(field) == (32, 32)
+        end
+
+        @testset "non-zero field" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test !all(iszero, field)
+        end
+
+        @testset "custom grid size" begin
+            field = reconstruct_field(solver, vecs[:, 1]; grid=(64, 64))
+
+            @test size(field) == (64, 64)
+        end
+    end
+
+    @testset "2D SH (scalar phononic)" begin
+        lat = square_lattice(1.0)
+        geo = Geometry(lat, IsotropicElastic(ρ=1000.0, λ=1e9, μ=1e9), [
+            (Circle([0.5, 0.5], 0.2), IsotropicElastic(ρ=2000.0, λ=2e9, μ=2e9))
+        ])
+        solver = Solver(SHWave(), geo, (32, 32); cutoff=5)
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+
+        @testset "basic reconstruction" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test field isa Matrix{ComplexF64}
+            @test size(field) == (32, 32)
+        end
+    end
+
+    # =========================================================================
+    # Phase 1A-3: 2D vector field
+    # =========================================================================
+    @testset "2D TE (scalar: Hz)" begin
+        lat = square_lattice(1.0)
+        geo = Geometry(lat, Dielectric(1.0), [
+            (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+        ])
+        solver = Solver(TEWave(), geo, (32, 32); cutoff=5)
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.1, 0.1], DenseMethod())  # non-zero k
+
+        @testset "reconstruct_field returns scalar for TE" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            # TEWave has ncomponents=1 so returns scalar
+            @test field isa Matrix{ComplexF64}
+            @test size(field) == (32, 32)
+        end
+    end
+
+    @testset "2D PSV (vector: ux, uy)" begin
+        lat = square_lattice(1.0)
+        geo = Geometry(lat, IsotropicElastic(ρ=1000.0, λ=1e9, μ=1e9), [
+            (Circle([0.5, 0.5], 0.2), IsotropicElastic(ρ=2000.0, λ=2e9, μ=2e9))
+        ])
+        solver = Solver(PSVWave(), geo, (32, 32); cutoff=5)
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.1, 0.1], DenseMethod())
+
+        @testset "reconstruct_field returns tuple for 2-component field" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            # PSVWave has ncomponents=2 so returns 2-element tuple
+            @test field isa Tuple{Matrix{ComplexF64}, Matrix{ComplexF64}}
+            @test length(field) == 2
+            @test size(field[1]) == (32, 32)
+            @test size(field[2]) == (32, 32)
+        end
+
+        @testset "both components are non-zero (at non-zero k)" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            @test !all(iszero, field[1])
+            @test !all(iszero, field[2])
+        end
+    end
+
+    # =========================================================================
+    # Phase 1A-4: 3D field
+    # =========================================================================
+    @testset "3D TransverseEM" begin
+        lat = cubic_lattice(1.0)
+        geo = Geometry(lat, Dielectric(1.0), [
+            (Sphere([0.5, 0.5, 0.5], 0.2), Dielectric(9.0))
+        ])
+        solver = Solver(TransverseEM(), geo, (16, 16, 16); cutoff=3)
+        freqs, vecs = solve_at_k_with_vectors(solver, [0.1, 0.1, 0.1], DenseMethod())
+
+        @testset "reconstruct_field returns tuple for 2-component 3D field" begin
+            field = reconstruct_field(solver, vecs[:, 1])
+
+            # TransverseEM has ncomponents=2
+            @test field isa Tuple{Array{ComplexF64,3}, Array{ComplexF64,3}}
+            @test length(field) == 2
+            @test size(field[1]) == (16, 16, 16)
+            @test size(field[2]) == (16, 16, 16)
+        end
+    end
+
+    # =========================================================================
+    # Phase 1A-5: get_epsilon_field / get_material_field
+    # =========================================================================
+    @testset "get_epsilon_field" begin
+        @testset "2D Photonic" begin
+            lat = square_lattice(1.0)
+            geo = Geometry(lat, Dielectric(1.0), [
+                (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+            ])
+            solver = Solver(TMWave(), geo, (32, 32); cutoff=5)
+
+            eps = get_epsilon_field(solver)
+
+            @test eps isa Matrix{Float64}
+            @test size(eps) == (32, 32)
+            @test minimum(eps) ≈ 1.0
+            @test maximum(eps) ≈ 9.0
+        end
+
+        @testset "1D Photonic" begin
+            lat = lattice_1d(1.0)
+            geo = Geometry(lat, Dielectric(1.0), [
+                (Segment(0.0, 0.3), Dielectric(4.0))
+            ])
+            solver = Solver(Photonic1D(), geo, (64,); cutoff=5)
+
+            eps = get_epsilon_field(solver)
+
+            @test eps isa Vector{Float64}
+            @test length(eps) == 64
+            @test minimum(eps) ≈ 1.0
+            @test maximum(eps) ≈ 4.0
+        end
+    end
+
+    @testset "get_material_field" begin
+        @testset "Phononic - density" begin
+            lat = square_lattice(1.0)
+            geo = Geometry(lat, IsotropicElastic(ρ=1000.0, λ=1e9, μ=1e9), [
+                (Circle([0.5, 0.5], 0.2), IsotropicElastic(ρ=2000.0, λ=2e9, μ=2e9))
+            ])
+            solver = Solver(SHWave(), geo, (32, 32); cutoff=5)
+
+            rho = get_material_field(solver, :ρ)
+
+            @test rho isa Matrix{Float64}
+            @test size(rho) == (32, 32)
+            @test minimum(rho) ≈ 1000.0
+            @test maximum(rho) ≈ 2000.0
+        end
+    end
+
+    # =========================================================================
+    # fix_phase
+    # =========================================================================
+    @testset "fix_phase" begin
+        @testset "method=:max makes maximum point real" begin
+            # Create complex field
+            field = [1.0 + 2.0im, 3.0 + 1.0im, 0.5 - 0.5im]
+
+            fixed = fix_phase(field; method=:max)
+
+            # Maximum amplitude point (2nd) should be real
+            max_idx = argmax(abs.(field))
+            @test abs(imag(fixed[max_idx])) < 1e-10
+            @test real(fixed[max_idx]) > 0  # positive real
+        end
+
+        @testset "amplitude is preserved" begin
+            field = randn(ComplexF64, 10)
+
+            fixed = fix_phase(field; method=:max)
+
+            @test abs.(field) ≈ abs.(fixed)
+        end
+
+        @testset "method=:center" begin
+            field = reshape(randn(ComplexF64, 9), 3, 3)
+
+            fixed = fix_phase(field; method=:center)
+
+            # Center point should be real
+            @test abs(imag(fixed[2, 2])) < 1e-10
+        end
+    end
+
+    # =========================================================================
+    # field_energy
+    # =========================================================================
+    @testset "field_energy" begin
+        @testset "2D TM energy is positive" begin
+            lat = square_lattice(1.0)
+            geo = Geometry(lat, Dielectric(1.0), [
+                (Circle([0.5, 0.5], 0.2), Dielectric(9.0))
+            ])
+            solver = Solver(TMWave(), geo, (32, 32); cutoff=5)
+            freqs, vecs = solve_at_k_with_vectors(solver, [0.0, 0.0], DenseMethod())
+
+            energy = field_energy(solver, vecs[:, 1])
+
+            @test energy isa Matrix{Float64}
+            @test size(energy) == (32, 32)
+            @test all(energy .>= 0)
+            @test sum(energy) > 0
+        end
+    end
+
+end  # @testset "Field Reconstruction"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2009,4 +2009,7 @@ using LinearAlgebra
 
     # Band sorting
     include("band_sorting_test.jl")
+
+    # Field reconstruction
+    include("field_test.jl")
 end


### PR DESCRIPTION
## Summary

Port field reconstruction and Plots.jl visualization from
`develop/v0.2.0` to `main`, with a new docs page and three examples.

## Test plan

- [x] `Pkg.test()` passes locally (1564 → 1611 tests)
- [x] Examples 811 / 812 / 813 run and produce expected PNGs
- [x] `docs/make.jl` builds; Field Visualization page rendered
- [ ] CI green

## Notes

- Manual port rather than cherry-pick: PR #29 restructured
  `PhoXonicPlotsExt`, so the original commit (`c51d94f`) no longer
  applies cleanly.
- Examples numbered **811-813** to avoid collision with the existing
  `examples/801_plot_structures.jl`.
- Minor: `examples/702_wilson_loop_2d.jl` uses `simple_kpath_square`
  for a faster band plot.

Closes #16