### PR TITLE
feat: Add savefig_publication via PythonPlot extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -41,9 +41,3 @@ RecipesBase = "1"
 ReducedShiftedKrylov = "0.1"
 StaticArrays = "1"
 julia = "1.9"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/docs/src/api-plotting.md
+++ b/docs/src/api-plotting.md
@@ -6,7 +6,7 @@ PhoXonic.jl provides two plotting paths via package extensions:
 |-----------|---------|---------------|
 | RecipesBaseExt | `using RecipesBase` (or any backend) | `plot(bs)` recipe for `BandStructure` |
 | PlotsExt | `using Plots` | `plot_bands`, `plot_bands!` (full-featured) |
-| PythonPlotExt | `using PythonPlot` | Planned |
+| PythonPlotExt | `using PythonPlot` | `savefig_publication` (publication-quality PDF/PNG) |
 
 ---
 
@@ -95,10 +95,60 @@ data = band_plot_data(bs; normalize=1.0)
 
 ---
 
+## PythonPlot — Publication-Quality Figures
+
+Activated when `using PythonPlot` is loaded. Provides `savefig_publication`
+for matplotlib-backed PDF/PNG output with precise axis-size control suitable
+for journal submissions.
+
+### `savefig_publication`
+
+Single `BandStructure`:
+
+```julia
+using PhoXonic, PythonPlot
+
+bs = compute_bands(solver, kpath)
+savefig_publication(bs, "bands.pdf"; axis_width_cm=8.0, axis_height_cm=6.0,
+                    title="TE Bands")
+```
+
+Multiple `BandStructure` as subplots:
+
+```julia
+savefig_publication([bs_te, bs_tm], "te_tm.pdf"; layout=(1, 2))
+```
+
+Multiple `BandStructure` as overlay (single axis):
+
+```julia
+savefig_publication([bs_te, bs_tm], "te_tm_overlay.pdf"; overlay=true,
+                    title="TE vs TM")
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `axis_width_cm` | Real | `8.0` | Axis width in centimeters |
+| `axis_height_cm` | Real | `6.0` | Axis height in centimeters |
+| `ylims` | Tuple or `nothing` | `nothing` | Y-axis range (auto if `nothing`) |
+| `title` | String | `""` | Plot title (suppressed if empty) |
+| `show_gaps` | Bool | `false` | Highlight band gaps with `axhspan` |
+| `normalize` | Real | `1.0` | Frequency normalization factor |
+| `layout` | Tuple | `(1, n)` | Subplot grid `(nrows, ncols)` |
+| `overlay` | Bool | `false` | Plot all on a single axis |
+
+The output format is inferred from the file extension (`.pdf`, `.png`, `.svg`,
+etc., as supported by matplotlib).
+
+---
+
 ## API Reference
 
 ```@docs
 plot_bands
 plot_bands!
 band_plot_data
+savefig_publication
 ```

--- a/ext/PhoXonicPythonPlotExt.jl
+++ b/ext/PhoXonicPythonPlotExt.jl
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of PhoXonic.jl - PythonPlot extension
+module PhoXonicPythonPlotExt
+
+using PhoXonic
+import PhoXonic: BandStructure, band_plot_data, savefig_publication
+import PythonPlot
+
+const CM_PER_INCH = 2.54
+
+"""
+Plot a single BandStructure on the given matplotlib Axes.
+"""
+function _plot_bs_on_ax!(ax, bs::BandStructure;
+                         color="black", linewidth=1.5, linestyle="-",
+                         show_gaps::Bool=false,
+                         normalize::Real=1.0,
+                         title::AbstractString="")
+    data = band_plot_data(bs; normalize)
+    nbands = size(data.frequencies, 2)
+
+    for i in 1:nbands
+        ax.plot(data.distances, data.frequencies[:, i];
+                color, linewidth, linestyle)
+    end
+
+    # Vertical lines at high-symmetry points
+    for pos in data.label_positions
+        ax.axvline(pos; color="gray", linewidth=0.5)
+    end
+
+    # Optional gap shading between consecutive bands
+    if show_gaps && nbands >= 2
+        for b in 1:nbands-1
+            max_lower = maximum(data.frequencies[:, b])
+            min_upper = minimum(data.frequencies[:, b+1])
+            if min_upper > max_lower
+                ax.axhspan(max_lower, min_upper; alpha=0.2, color="yellow")
+            end
+        end
+    end
+
+    ax.set_xticks(data.label_positions)
+    ax.set_xticklabels(data.label_names)
+    ax.set_ylabel("Frequency")
+    if !isempty(title)
+        ax.set_title(title)
+    end
+    ax.set_xlim(data.distances[1], data.distances[end])
+end
+
+"""
+Compute figure size (inches) and axes positions from axis dimensions and layout.
+"""
+function _layout_axes(axis_width_cm, axis_height_cm, n;
+                      margin_left_cm=1.5, margin_right_cm=0.3,
+                      margin_bottom_cm=1.0, margin_top_cm=0.8,
+                      hgap_cm=1.8, vgap_cm=1.5,
+                      nrows=1, ncols=1)
+    widths = axis_width_cm isa AbstractVector ? axis_width_cm : fill(axis_width_cm, ncols)
+    heights = axis_height_cm isa AbstractVector ? axis_height_cm : fill(axis_height_cm, nrows)
+
+    fig_w_cm = margin_left_cm + sum(widths) + hgap_cm * (ncols - 1) + margin_right_cm
+    fig_h_cm = margin_bottom_cm + sum(heights) + vgap_cm * (nrows - 1) + margin_top_cm
+
+    fig_w = fig_w_cm / CM_PER_INCH
+    fig_h = fig_h_cm / CM_PER_INCH
+
+    positions = Vector{NTuple{4,Float64}}()
+    for row in 1:nrows
+        for col in 1:ncols
+            left = (margin_left_cm + sum(widths[1:col-1]) + hgap_cm * (col - 1)) / fig_w_cm
+            bottom = (margin_bottom_cm + sum(heights[row+1:end]) + vgap_cm * (nrows - row)) / fig_h_cm
+            w = widths[col] / fig_w_cm
+            h = heights[row] / fig_h_cm
+            push!(positions, (left, bottom, w, h))
+        end
+    end
+
+    return fig_w, fig_h, positions
+end
+
+# ── Single BandStructure ──
+
+function PhoXonic.savefig_publication(
+    bs::BandStructure, path::AbstractString;
+    axis_width_cm=8.0, axis_height_cm=6.0,
+    ylims=nothing,
+    kwargs...)
+
+    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
+
+    fig = PythonPlot.figure(figsize=(fig_w, fig_h))
+    ax = fig.add_axes(collect(positions[1]))
+
+    _plot_bs_on_ax!(ax, bs; kwargs...)
+    if ylims !== nothing
+        ax.set_ylim(ylims...)
+    end
+
+    fig.savefig(path)
+    PythonPlot.close(fig)
+    return path
+end
+
+# Default colors/styles for overlay
+const _OVERLAY_STYLES = [
+    (color="black",  linewidth=1.5, linestyle="-"),
+    (color="blue",   linewidth=1.2, linestyle="--"),
+    (color="red",    linewidth=1.2, linestyle="-."),
+    (color="green",  linewidth=1.2, linestyle=":"),
+    (color="purple", linewidth=1.2, linestyle="--"),
+]
+
+# ── Vector{BandStructure} ──
+
+function PhoXonic.savefig_publication(
+    bss::AbstractVector{<:BandStructure}, path::AbstractString;
+    axis_width_cm=8.0, axis_height_cm=6.0,
+    layout=(1, length(bss)),
+    overlay::Bool=false,
+    ylims=nothing,
+    title::AbstractString="",
+    kwargs...)
+
+    if overlay
+        fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
+        fig = PythonPlot.figure(figsize=(fig_w, fig_h))
+        ax = fig.add_axes(collect(positions[1]))
+
+        for (i, bs) in enumerate(bss)
+            style = _OVERLAY_STYLES[mod1(i, length(_OVERLAY_STYLES))]
+            _plot_bs_on_ax!(ax, bs;
+                color=style.color, linewidth=style.linewidth,
+                linestyle=style.linestyle)
+        end
+
+        if ylims !== nothing
+            ax.set_ylim(ylims...)
+        end
+        if !isempty(title)
+            ax.set_title(title)
+        end
+    else
+        nrows, ncols = layout
+        n = length(bss)
+
+        fig_w, fig_h, positions = _layout_axes(
+            axis_width_cm, axis_height_cm, n;
+            nrows, ncols)
+
+        fig = PythonPlot.figure(figsize=(fig_w, fig_h))
+
+        for (i, bs) in enumerate(bss)
+            i > length(positions) && break
+            ax = fig.add_axes(collect(positions[i]))
+            _plot_bs_on_ax!(ax, bs; kwargs...)
+            if ylims !== nothing
+                ax.set_ylim(ylims...)
+            end
+        end
+    end
+
+    fig.savefig(path)
+    PythonPlot.close(fig)
+    return path
+end
+
+end # module

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -64,10 +64,23 @@ function plot_bands! end
 # These stubs only exist to provide docstrings and allow pre-declaration
 
 """
-    savefig_publication(bs::BandStructure, filename::AbstractString; kwargs...)
+    savefig_publication(bs::BandStructure, path; kwargs...)
+    savefig_publication(bss::AbstractVector{<:BandStructure}, path; kwargs...)
 
-Save a publication-quality band structure figure using PythonPlot.
-Requires `using PythonPlot`.
+Save a publication-quality band structure figure via the PythonPlot extension.
+Requires `using PythonPlot` to activate `PhoXonicPythonPlotExt`.
+
+The output format is inferred from the file extension (`.pdf`, `.png`, `.svg`, ...).
+
+# Keyword arguments
+
+- `axis_width_cm = 8.0`, `axis_height_cm = 6.0` — Axis size in centimeters.
+- `ylims = nothing` — Y-axis range (auto if `nothing`).
+- `title = ""` — Plot title (suppressed if empty).
+- `show_gaps = false` — Shade band gaps with `axhspan`.
+- `normalize = 1.0` — Frequency normalization factor (forwarded to `band_plot_data`).
+- `layout = (1, length(bss))` — Subplot grid for the vector overload.
+- `overlay = false` — Plot all `bss` on a single axis (vector overload).
 
 See also: [`plot_bands`](@ref) for interactive plotting with Plots.jl.
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
+ReducedShiftedKrylov = "4d429029-a74f-409e-95c5-00936df3696f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2012,4 +2012,7 @@ using LinearAlgebra
 
     # Field reconstruction
     include("field_test.jl")
+
+    # PythonPlot extension: savefig_publication
+    include("test_publication.jl")
 end

--- a/test/test_publication.jl
+++ b/test/test_publication.jl
@@ -1,0 +1,113 @@
+using Test
+using PhoXonic
+using PythonPlot
+using StaticArrays
+
+@testset "savefig_publication (PythonPlot)" begin
+    # Lightweight 2D BandStructure fixture (4 k-points × 3 bands)
+    bs2 = PhoXonic.BandStructure{2}(
+        [SVector(0.0, 0.0), SVector(0.5, 0.0), SVector(0.5, 0.5), SVector(0.0, 0.0)],
+        [0.0, 1.0, 2.0, 3.0],
+        Float64[0.10 0.30 0.55;
+                0.20 0.40 0.65;
+                0.15 0.35 0.60;
+                0.05 0.25 0.50],
+        [(1, "Γ"), (2, "X"), (3, "M"), (4, "Γ")],
+    )
+
+    # Lightweight 3D BandStructure fixture
+    bs3 = PhoXonic.BandStructure{3}(
+        [SVector(0.0, 0.0, 0.0), SVector(0.5, 0.0, 0.0),
+         SVector(0.5, 0.5, 0.0), SVector(0.5, 0.5, 0.5),
+         SVector(0.0, 0.0, 0.0)],
+        [0.0, 1.0, 2.0, 3.0, 4.0],
+        Float64[0.10 0.30 0.55;
+                0.20 0.40 0.65;
+                0.15 0.35 0.60;
+                0.18 0.38 0.62;
+                0.05 0.25 0.50],
+        [(1, "Γ"), (2, "X"), (3, "M"), (4, "R"), (5, "Γ")],
+    )
+
+    @testset "BandStructure{2} 単体" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "bs2.pdf")
+            ret = savefig_publication(bs2, path)
+            @test isfile(path)
+            @test ret == path
+            @test filesize(path) > 0
+        end
+    end
+
+    @testset "BandStructure{3} 単体" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "bs3.pdf")
+            savefig_publication(bs3, path)
+            @test isfile(path)
+        end
+    end
+
+    @testset "axis_width_cm / axis_height_cm カスタム" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "custom_size.pdf")
+            savefig_publication(bs2, path; axis_width_cm=10.0, axis_height_cm=5.0)
+            @test isfile(path)
+        end
+    end
+
+    @testset "title kwarg" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "with_title.pdf")
+            savefig_publication(bs2, path; title="Test Bands")
+            @test isfile(path)
+        end
+    end
+
+    @testset "ylims kwarg" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "ylims.pdf")
+            savefig_publication(bs2, path; ylims=(0.0, 1.0))
+            @test isfile(path)
+        end
+    end
+
+    @testset "show_gaps" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "gaps.pdf")
+            savefig_publication(bs2, path; show_gaps=true)
+            @test isfile(path)
+        end
+    end
+
+    @testset "subplot layout=(1,2)" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "subplot_1x2.pdf")
+            savefig_publication([bs2, bs2], path; layout=(1, 2))
+            @test isfile(path)
+        end
+    end
+
+    @testset "subplot layout=(2,1)" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "subplot_2x1.pdf")
+            savefig_publication([bs2, bs2], path; layout=(2, 1))
+            @test isfile(path)
+        end
+    end
+
+    @testset "overlay モード" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "overlay.pdf")
+            savefig_publication([bs2, bs2], path; overlay=true)
+            @test isfile(path)
+        end
+    end
+
+    @testset "PNG 出力" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "bs2.png")
+            savefig_publication(bs2, path)
+            @test isfile(path)
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- `PhoXonicPythonPlotExt`: `savefig_publication` (PDF/PNG, axis-size control, subplot / overlay / `show_gaps`)
- Test env: `[extras]/[targets]` → `test/Project.toml` (needed to load PythonPlot)
- 12 new testsets, 1623/1623 pass

No breaking changes. Fallback preserved.

## Test plan

- [x] `Pkg.test()` 1623/1623
- [x] Real-data PDF smoke test (single / overlay / subplot / show_gaps)
- [x] `docs/make.jl` builds
- [ ] CI matrix

Closes #30