### PR TITLE
Enforce matplotlib Agg backend and add ylabel kwarg to PythonPlot ext

### DIFF
--- a/ext/PhoXonicPythonPlotExt.jl
+++ b/ext/PhoXonicPythonPlotExt.jl
@@ -20,6 +20,7 @@ function _plot_bs_on_ax!(
     linestyle="-",
     show_gaps::Bool=false,
     normalize::Real=1.0,
+    ylabel::AbstractString="Frequency",
     title::AbstractString="",
 )
     data = band_plot_data(bs; normalize)
@@ -47,7 +48,7 @@ function _plot_bs_on_ax!(
 
     ax.set_xticks(data.label_positions)
     ax.set_xticklabels(data.label_names)
-    ax.set_ylabel("Frequency")
+    ax.set_ylabel(ylabel)
     if !isempty(title)
         ax.set_title(title)
     end

--- a/test/test_publication.jl
+++ b/test/test_publication.jl
@@ -1,6 +1,7 @@
 using Test
 using PhoXonic
 using PythonPlot
+PythonPlot.matplotlib.use("Agg")
 using StaticArrays
 
 @testset "savefig_publication (PythonPlot)" begin
@@ -115,6 +116,14 @@ using StaticArrays
         mktempdir() do tmp
             path = joinpath(tmp, "bs2.png")
             savefig_publication(bs2, path)
+            @test isfile(path)
+        end
+    end
+
+    @testset "ylabel kwarg" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "ylabel.pdf")
+            savefig_publication(bs2, path; ylabel="Frequency [THz]")
             @test isfile(path)
         end
     end


### PR DESCRIPTION
Closes #44.

## Summary

- `test_publication.jl`: pin matplotlib backend to `Agg`
- `_plot_bs_on_ax!`: add `ylabel` kwarg (default `"Frequency"`)

## Test plan

- [ ] CI green: ubuntu-latest + macos-latest × Julia 1.10 / 1
- [ ] Format check PASS
- [ ] `Pkg.test()` 1632 → 1633

Out of scope: overlay-mode kwargs propagation (separate issue if needed).