### PR TITLE
docs: add CONTRIBUTING.md and integrate ext tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to PhoXonic.jl
+
+## Running tests
+
+PhoXonic.jl uses a split test runner:
+
+- `Pkg.test()` — runs all tests (default, ~3 min)
+- `Pkg.test(; test_args=["core"])` — core tests only (~1.5 min)
+- `Pkg.test(; test_args=["ext"])` — extension tests only (~1 min)
+
+CI runs both groups in parallel via `test_group: [core, ext]` matrix.
+
+## Extensions
+
+| Extension | Trigger package | Test file |
+|---|---|---|
+| `PhoXonicPlotsExt` | `Plots`, `RecipesBase` | `test/plotsext_test.jl` |
+| `PhoXonicPythonPlotExt` | `PythonPlot` | `test/test_publication.jl` |
+| `PhoXonicRecipesBaseExt` | `RecipesBase` | (covered transitively by `Plots` test) |
+| `PhoXonicReducedShiftedKrylovExt` | `ReducedShiftedKrylov` | `test/rsk_ext/runtests.jl` |
+
+`test/ext_tests.jl` includes the test files listed above.
+
+## Adding a new extension test
+
+1. Add the trigger package to `test/Project.toml`.
+2. Create `test/<name>ext_test.jl`.
+3. Add `include("<name>ext_test.jl")` to `test/ext_tests.jl`.
+
+## Code style
+
+JuliaFormatter v2 (Blue style via `.JuliaFormatter.toml`) is enforced
+by the `Format Check` workflow. Run `JuliaFormatter.format(".")`
+before commit.
+
+## Quality checks
+
+`Aqua.jl` (in core test group) checks for ambiguities, undefined
+exports, stale deps, and missing compat entries.
+
+## Release
+
+Maintainer workflow:
+
+1. Bump version in `Project.toml`, `CITATION.cff`, `README.md`,
+   and `docs/src/index.md`.
+2. Open a PR titled `chore: bump version to vX.Y.Z`.
+3. After merge, comment `@JuliaRegistrator register` on the merge
+   commit (see [General registry](https://github.com/JuliaRegistries/General)).
+4. TagBot creates the git tag and GitHub Release. Zenodo issues a
+   per-version DOI.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ See the [full documentation](https://hsugawa8651.github.io/PhoXonic.jl/dev/) for
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or pull request on [GitHub](https://github.com/hsugawa8651/PhoXonic.jl).
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+test pipeline, code style, and release workflow. Please open an issue or
+pull request on [GitHub](https://github.com/hsugawa8651/PhoXonic.jl).
 
 ## Citation
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 ReducedShiftedKrylov = "4d429029-a74f-409e-95c5-00936df3696f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -8,3 +9,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+Plots = "1"

--- a/test/ext_tests.jl
+++ b/test/ext_tests.jl
@@ -1,4 +1,7 @@
 @testset "PhoXonic.jl (ext)" begin
     # PythonPlot extension: savefig_publication
     include("test_publication.jl")
+
+    # ReducedShiftedKrylov extension
+    include("rsk_ext/runtests.jl")
 end

--- a/test/ext_tests.jl
+++ b/test/ext_tests.jl
@@ -4,4 +4,7 @@
 
     # ReducedShiftedKrylov extension
     include("rsk_ext/runtests.jl")
+
+    # Plots extension (RecipesBase ext is covered transitively via Plots)
+    include("plotsext_test.jl")
 end

--- a/test/plotsext_test.jl
+++ b/test/plotsext_test.jl
@@ -1,0 +1,18 @@
+using Test
+using PhoXonic
+using Plots
+using StaticArrays
+
+@testset "PhoXonicPlotsExt smoke" begin
+    bs = PhoXonic.BandStructure{2}(
+        [SVector(0.0, 0.0), SVector(0.5, 0.0)],
+        [0.0, 1.0],
+        Float64[
+            0.10 0.30
+            0.20 0.40
+        ],
+        [(1, "Γ"), (2, "X")],
+    )
+    p = plot_bands(bs)
+    @test p isa Plots.Plot
+end


### PR DESCRIPTION
Closes #54.

## Summary

- New `CONTRIBUTING.md` (root) documenting the split test runner and ext layout.
- README links to the new document.
- `test/ext_tests.jl` now includes `rsk_ext/runtests.jl` (orphan resolved).
- New `test/plotsext_test.jl` — smoke test for `PhoXonicPlotsExt`
  (covers `PhoXonicRecipesBaseExt` transitively via `Plots`).

## Test plan

- [ ] CI green: 8 jobs (Julia 1.10/1 × ubuntu/macos × core/ext)
- [ ] Format check pass
- [ ] `Pkg.test()` 1633 → 1647 (core 1620 + ext 27)