### PR TITLE
Add 3-layer PythonPlot API (plot_on_axis! / figure_publication); switch to mm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 docs/build/
 Manifest.toml
+.CondaPkg/
 
 # Examples output
 examples/*.png

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PhoXonic = "f8e5d5a0-1234-4567-89ab-cdef01234567"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 
 [compat]
 Documenter = "1"
+PythonPlot = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,15 @@
 using Documenter
 using PhoXonic
+using PythonPlot                  # loads PhoXonicPythonPlotExt so its docstrings render
+PythonPlot.matplotlib.use("Agg")  # headless backend for CI
+
+# The PythonPlot extension carries the per-method docstrings for plot_on_axis! /
+# figure_publication; include it so @docs can render them.
+const PXPythonPlotExt = Base.get_extension(PhoXonic, :PhoXonicPythonPlotExt)
 
 makedocs(;
     sitename="PhoXonic.jl",
-    modules=[PhoXonic],
+    modules=[PhoXonic, PXPythonPlotExt],
     format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"),
     pages=[
         "Home" => "index.md",

--- a/docs/src/api-plotting.md
+++ b/docs/src/api-plotting.md
@@ -1,12 +1,12 @@
 # Plotting
 
-PhoXonic.jl provides two plotting paths via package extensions:
+PhoXonic.jl provides three plotting paths via package extensions:
 
 | Extension | Trigger | Functionality |
 |-----------|---------|---------------|
 | RecipesBaseExt | `using RecipesBase` (or any backend) | `plot(bs)` recipe for `BandStructure` |
 | PlotsExt | `using Plots` | `plot_bands`, `plot_bands!` (full-featured) |
-| PythonPlotExt | `using PythonPlot` | `savefig_publication` (publication-quality PDF/PNG) |
+| PythonPlotExt | `using PythonPlot` | 3-layer API `plot_on_axis!` / `figure_publication` / `savefig_publication` for publication-quality static PDF / PNG |
 
 ---
 
@@ -97,11 +97,41 @@ data = band_plot_data(bs; normalize=1.0)
 
 ## PythonPlot — Publication-Quality Figures
 
-Activated when `using PythonPlot` is loaded. Provides `savefig_publication`
-for matplotlib-backed PDF/PNG output with precise axis-size control suitable
-for journal submissions.
+Activated when `using PythonPlot` is loaded. Provides matplotlib-backed PDF / PNG
+output with precise axis-size control (in millimeters) suitable for journal
+submissions. The API has **three layers** — L1 / L2 are unexported (call them as
+`PhoXonic.…`); L3 `savefig_publication` is exported:
 
-### `savefig_publication`
+| Layer | Function | Returns | Use |
+|-------|----------|---------|-----|
+| L3 | `savefig_publication(bs, path; ...)` | `path` | save to PDF or PNG in one call (format from the file extension; delegates to L2) |
+| L2 | `PhoXonic.figure_publication(bs; ...)` | `(fig, ax)` | a sized figure + axis to tweak before saving |
+| L1 | `PhoXonic.plot_on_axis!(ax, bs; ...)` | `ax` | draw onto your own matplotlib axis (compose a subplot grid) |
+
+L2 and L3 (single `BandStructure`) take `axis_width_mm` / `axis_height_mm`; the
+vector `savefig_publication` overload is **L3-only** and additionally takes
+`layout` / `overlay` (see [Multiple band structures](@ref) below).
+
+**Headless / CI.** matplotlib needs a non-interactive backend when there is no
+display. Either set the environment variable *before* `using PythonPlot`
+
+```julia
+ENV["MPLBACKEND"] = "Agg"
+using PhoXonic, PythonPlot
+```
+
+or select it explicitly after import: `PythonPlot.matplotlib.use("Agg")`.
+
+!!! note "PhoXonic specifics"
+    - **Millimeters only.** Axis sizes are given in mm (`axis_width_mm`,
+      `axis_height_mm`); there is no `cm` keyword.
+    - **`xlabel` is empty by default.** The horizontal axis is labelled with
+      high-symmetry-point xticks (Γ, X, M, …), so no axis title is drawn unless
+      you pass a non-empty `xlabel`.
+    - **No colorbar.** Band structures are line plots; the colorbar-related
+      keywords found in other PhoXonic ecosystem packages do not apply here.
+
+### `savefig_publication` (L3)
 
 Single `BandStructure`:
 
@@ -109,29 +139,41 @@ Single `BandStructure`:
 using PhoXonic, PythonPlot
 
 bs = compute_bands(solver, kpath)
-savefig_publication(bs, "bands.pdf"; axis_width_cm=8.0, axis_height_cm=6.0,
+savefig_publication(bs, "bands.pdf"; axis_width_mm=80.0, axis_height_mm=60.0,
                     title="TE Bands")
 ```
 
-Multiple `BandStructure` as subplots:
+#### Multiple band structures
+
+A `Vector` of `BandStructure` is supported **only at L3** (`savefig_publication`);
+there is no `figure_publication` overload for vectors. Two modes are available:
+
+*Grid* — one panel per band structure (`layout = (nrows, ncols)`):
 
 ```julia
 savefig_publication([bs_te, bs_tm], "te_tm.pdf"; layout=(1, 2))
 ```
 
-Multiple `BandStructure` as overlay (single axis):
+*Overlay* — all band structures on a single axis, cycling through preset line
+styles (`overlay = true`):
 
 ```julia
 savefig_publication([bs_te, bs_tm], "te_tm_overlay.pdf"; overlay=true,
                     title="TE vs TM")
 ```
 
+Plot keywords (`show_gaps`, `normalize`, `ylabel`, …) are forwarded to each panel
+in both modes; in overlay mode an explicit `color` / `linewidth` / `linestyle`
+overrides the preset style for every curve. To compose vectors more freely (e.g.
+mixed layouts), use [`plot_on_axis!`](@ref PhoXonic.plot_on_axis!) with your own
+`subplots()`.
+
 ### Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `axis_width_cm` | Real | `8.0` | Axis width in centimeters |
-| `axis_height_cm` | Real | `6.0` | Axis height in centimeters |
+| `axis_width_mm` | Real | `80.0` | Axis width in millimeters |
+| `axis_height_mm` | Real | `60.0` | Axis height in millimeters |
 | `ylims` | Tuple or `nothing` | `nothing` | Y-axis range (auto if `nothing`) |
 | `title` | String | `""` | Plot title (suppressed if empty) |
 | `show_gaps` | Bool | `false` | Highlight band gaps with `axhspan` |
@@ -142,6 +184,59 @@ savefig_publication([bs_te, bs_tm], "te_tm_overlay.pdf"; overlay=true,
 The output format is inferred from the file extension (`.pdf`, `.png`, `.svg`,
 etc., as supported by matplotlib).
 
+### Composing subplots with `plot_on_axis!` (L1) / `figure_publication` (L2)
+
+Beyond `savefig_publication` (L3) shown above, the two lower layers let you
+compose and tweak figures.
+
+**L1 — compose multiple band structures into one figure.** You create the
+figure with matplotlib's `subplots`/`add_subplot` and own the `close`:
+
+```julia
+using PhoXonic, PythonPlot
+
+fig = PythonPlot.figure(figsize = (10, 4))
+PhoXonic.plot_on_axis!(fig.add_subplot(1, 2, 1), bs_te; title = "TE")
+PhoXonic.plot_on_axis!(fig.add_subplot(1, 2, 2), bs_tm; title = "TM")
+fig.savefig("te_tm_panel.pdf")
+PythonPlot.close(fig)            # caller owns the figure
+```
+
+The plot keyword arguments are the same as for `savefig_publication`
+(e.g. `title`, `color`, `linewidth`, `linestyle`, `show_gaps`, `normalize`,
+`ylabel`). PhoXonic uses high-symmetry-point xticks for the horizontal axis, so
+`xlabel` is empty by default; pass a non-empty `xlabel` to add one.
+`plot_on_axis!` returns the same `ax` for chaining.
+
+**L2 — adjust before saving:**
+
+```julia
+fig, ax = PhoXonic.figure_publication(bs; axis_width_mm = 100.0)
+ax.axhline(0.5; linestyle = "--")     # add your own annotations
+fig.savefig("annotated.pdf")
+PythonPlot.close(fig)
+```
+
+!!! note
+    Inside the extension, figures are created with `PythonPlot.figure(...)` (not
+    `subplots()`), but on the **caller** side `subplots()` is fine — you just own
+    the resulting figure and must `close` it yourself.
+
+On a headless machine or in CI (no display), select a non-interactive backend
+before plotting: `PythonPlot.matplotlib.use("Agg")`.
+
+### Installing PythonPlot
+
+The extension loads automatically once both `PhoXonic` and `PythonPlot` are
+imported in the same session. Install it with:
+
+```julia
+using Pkg
+Pkg.add("PythonPlot")
+```
+
+CondaPkg.jl will install matplotlib on first use.
+
 ---
 
 ## API Reference
@@ -151,4 +246,6 @@ plot_bands
 plot_bands!
 band_plot_data
 savefig_publication
+PhoXonic.figure_publication
+PhoXonic.plot_on_axis!
 ```

--- a/ext/PhoXonicPythonPlotExt.jl
+++ b/ext/PhoXonicPythonPlotExt.jl
@@ -5,9 +5,10 @@ module PhoXonicPythonPlotExt
 
 using PhoXonic
 import PhoXonic: BandStructure, band_plot_data, savefig_publication
+import PhoXonic: plot_on_axis!, figure_publication
 using PythonPlot: PythonPlot
 
-const CM_PER_INCH = 2.54
+const MM_PER_INCH = 25.4
 
 """
 Plot a single BandStructure on the given matplotlib Axes.
@@ -55,42 +56,74 @@ function _plot_bs_on_ax!(
     ax.set_xlim(data.distances[1], data.distances[end])
 end
 
+# ── L1: plot_on_axis! ──
+
+"""
+    plot_on_axis!(ax, bs::BandStructure; kwargs...) -> ax
+
+Draw a [`BandStructure`](@ref) onto `ax` and return `ax`. Bands are drawn as
+lines with vertical guides and tick labels at the high-symmetry points.
+Requires `using PythonPlot`; not exported (call as `PhoXonic.plot_on_axis!`).
+
+# Arguments
+
+- `ax`: a matplotlib axis (PythonCall `Py`) to draw onto
+- `bs::BandStructure`: the band structure to plot
+
+# Keywords
+
+- `color="black"`: line color
+- `linewidth=1.5`: line width
+- `linestyle="-"`: line style
+- `show_gaps::Bool=false`: shade band gaps between consecutive bands with `axhspan`
+- `normalize::Real=1.0`: frequency normalization factor (forwarded to `band_plot_data`)
+- `xlabel::AbstractString=""`: x axis label; empty leaves the axis labelled only by
+    the high-symmetry-point xticks
+- `ylabel::AbstractString="Frequency"`: y axis label
+- `title::AbstractString=""`: title; empty leaves the axes untitled
+"""
+function plot_on_axis!(ax, bs::BandStructure; xlabel::AbstractString="", kwargs...)
+    _plot_bs_on_ax!(ax, bs; kwargs...)
+    isempty(xlabel) || ax.set_xlabel(xlabel)
+    return ax
+end
+
 """
 Compute figure size (inches) and axes positions from axis dimensions and layout.
 """
 function _layout_axes(
-    axis_width_cm,
-    axis_height_cm,
+    axis_width_mm,
+    axis_height_mm,
     n;
-    margin_left_cm=1.5,
-    margin_right_cm=0.3,
-    margin_bottom_cm=1.0,
-    margin_top_cm=0.8,
-    hgap_cm=1.8,
-    vgap_cm=1.5,
+    margin_left_mm=15.0,
+    margin_right_mm=3.0,
+    margin_bottom_mm=10.0,
+    margin_top_mm=8.0,
+    hgap_mm=18.0,
+    vgap_mm=15.0,
     nrows=1,
     ncols=1,
 )
-    widths = axis_width_cm isa AbstractVector ? axis_width_cm : fill(axis_width_cm, ncols)
+    widths = axis_width_mm isa AbstractVector ? axis_width_mm : fill(axis_width_mm, ncols)
     heights =
-        axis_height_cm isa AbstractVector ? axis_height_cm : fill(axis_height_cm, nrows)
+        axis_height_mm isa AbstractVector ? axis_height_mm : fill(axis_height_mm, nrows)
 
-    fig_w_cm = margin_left_cm + sum(widths) + hgap_cm * (ncols - 1) + margin_right_cm
-    fig_h_cm = margin_bottom_cm + sum(heights) + vgap_cm * (nrows - 1) + margin_top_cm
+    fig_w_mm = margin_left_mm + sum(widths) + hgap_mm * (ncols - 1) + margin_right_mm
+    fig_h_mm = margin_bottom_mm + sum(heights) + vgap_mm * (nrows - 1) + margin_top_mm
 
-    fig_w = fig_w_cm / CM_PER_INCH
-    fig_h = fig_h_cm / CM_PER_INCH
+    fig_w = fig_w_mm / MM_PER_INCH
+    fig_h = fig_h_mm / MM_PER_INCH
 
     positions = Vector{NTuple{4,Float64}}()
     for row in 1:nrows
         for col in 1:ncols
             left =
-                (margin_left_cm + sum(widths[1:(col - 1)]) + hgap_cm * (col - 1)) / fig_w_cm
+                (margin_left_mm + sum(widths[1:(col - 1)]) + hgap_mm * (col - 1)) / fig_w_mm
             bottom =
-                (margin_bottom_cm + sum(heights[(row + 1):end]) + vgap_cm * (nrows - row)) /
-                fig_h_cm
-            w = widths[col] / fig_w_cm
-            h = heights[row] / fig_h_cm
+                (margin_bottom_mm + sum(heights[(row + 1):end]) + vgap_mm * (nrows - row)) /
+                fig_h_mm
+            w = widths[col] / fig_w_mm
+            h = heights[row] / fig_h_mm
             push!(positions, (left, bottom, w, h))
         end
     end
@@ -98,28 +131,56 @@ function _layout_axes(
     return fig_w, fig_h, positions
 end
 
-# ── Single BandStructure ──
+# ── L2: figure_publication (single BandStructure only) ──
 
-function PhoXonic.savefig_publication(
-    bs::BandStructure,
-    path::AbstractString;
-    axis_width_cm=8.0,
-    axis_height_cm=6.0,
-    ylims=nothing,
-    kwargs...,
+"""
+    figure_publication(bs; axis_width_mm=80.0, axis_height_mm=60.0, ylims=nothing, kwargs...) -> (fig, ax)
+
+Create a publication matplotlib figure and a single axis for `bs`, draw it via
+[`plot_on_axis!`](@ref), and return `(fig, ax)` so you can tweak it before
+saving. The caller owns the figure and must call `PythonPlot.close(fig)`. Single
+`BandStructure` only; for a `Vector` use [`savefig_publication`](@ref) or compose
+with [`plot_on_axis!`](@ref) and your own `subplots()`. Requires `using
+PythonPlot`; not exported (call as `PhoXonic.figure_publication`).
+
+# Arguments
+
+- `bs::BandStructure`: the band structure to plot
+
+# Keywords
+
+- `axis_width_mm=80.0`: plotting area width in mm
+- `axis_height_mm=60.0`: plotting area height in mm
+- `ylims=nothing`: pass a tuple to override the y axis limits
+- `kwargs...`: forwarded to [`plot_on_axis!`](@ref)
+"""
+function figure_publication(
+    bs::BandStructure; axis_width_mm=80.0, axis_height_mm=60.0, ylims=nothing, kwargs...
 )
-    fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
-
+    fig_w, fig_h, positions = _layout_axes(axis_width_mm, axis_height_mm, 1)
     fig = PythonPlot.figure(; figsize=(fig_w, fig_h))
-    ax = fig.add_axes(collect(positions[1]))
-
-    _plot_bs_on_ax!(ax, bs; kwargs...)
-    if ylims !== nothing
-        ax.set_ylim(ylims...)
+    try
+        ax = fig.add_axes(collect(positions[1]))
+        plot_on_axis!(ax, bs; kwargs...)
+        if ylims !== nothing
+            ax.set_ylim(ylims...)
+        end
+        return fig, ax
+    catch
+        PythonPlot.close(fig)
+        rethrow()
     end
+end
 
-    fig.savefig(path)
-    PythonPlot.close(fig)
+# ── L3: savefig_publication (single BandStructure → L2 delegation) ──
+
+function PhoXonic.savefig_publication(bs::BandStructure, path::AbstractString; kwargs...)
+    fig, _ = figure_publication(bs; kwargs...)
+    try
+        fig.savefig(path)
+    finally
+        PythonPlot.close(fig)
+    end
     return path
 end
 
@@ -132,13 +193,13 @@ const _OVERLAY_STYLES = [
     (color="purple", linewidth=1.2, linestyle="--"),
 ]
 
-# ── Vector{BandStructure} ──
+# ── L3: savefig_publication (Vector{BandStructure} → L1 direct loop, no L2) ──
 
 function PhoXonic.savefig_publication(
     bss::AbstractVector{<:BandStructure},
     path::AbstractString;
-    axis_width_cm=8.0,
-    axis_height_cm=6.0,
+    axis_width_mm=80.0,
+    axis_height_mm=60.0,
     layout=(1, length(bss)),
     overlay::Bool=false,
     ylims=nothing,
@@ -146,49 +207,43 @@ function PhoXonic.savefig_publication(
     kwargs...,
 )
     if overlay
-        fig_w, fig_h, positions = _layout_axes(axis_width_cm, axis_height_cm, 1)
-        fig = PythonPlot.figure(; figsize=(fig_w, fig_h))
-        ax = fig.add_axes(collect(positions[1]))
-
-        for (i, bs) in enumerate(bss)
-            style = _OVERLAY_STYLES[mod1(i, length(_OVERLAY_STYLES))]
-            _plot_bs_on_ax!(
-                ax,
-                bs;
-                color=style.color,
-                linewidth=style.linewidth,
-                linestyle=style.linestyle,
-            )
-        end
-
-        if ylims !== nothing
-            ax.set_ylim(ylims...)
-        end
-        if !isempty(title)
-            ax.set_title(title)
-        end
+        fig_w, fig_h, positions = _layout_axes(axis_width_mm, axis_height_mm, 1)
     else
         nrows, ncols = layout
-        n = length(bss)
-
         fig_w, fig_h, positions = _layout_axes(
-            axis_width_cm, axis_height_cm, n; nrows, ncols
+            axis_width_mm, axis_height_mm, length(bss); nrows, ncols
         )
+    end
 
-        fig = PythonPlot.figure(; figsize=(fig_w, fig_h))
-
-        for (i, bs) in enumerate(bss)
-            i > length(positions) && break
-            ax = fig.add_axes(collect(positions[i]))
-            _plot_bs_on_ax!(ax, bs; kwargs...)
+    fig = PythonPlot.figure(; figsize=(fig_w, fig_h))
+    try
+        if overlay
+            ax = fig.add_axes(collect(positions[1]))
+            for (i, bs) in enumerate(bss)
+                style = _OVERLAY_STYLES[mod1(i, length(_OVERLAY_STYLES))]
+                plot_on_axis!(ax, bs; style..., kwargs...)
+            end
             if ylims !== nothing
                 ax.set_ylim(ylims...)
             end
+            if !isempty(title)
+                ax.set_title(title)
+            end
+        else
+            for (i, bs) in enumerate(bss)
+                i > length(positions) && break
+                ax = fig.add_axes(collect(positions[i]))
+                plot_on_axis!(ax, bs; kwargs...)
+                if ylims !== nothing
+                    ax.set_ylim(ylims...)
+                end
+            end
         end
-    end
 
-    fig.savefig(path)
-    PythonPlot.close(fig)
+        fig.savefig(path)
+    finally
+        PythonPlot.close(fig)
+    end
     return path
 end
 

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -7,3 +7,19 @@ function savefig_publication(args...; kwargs...)
         ),
     )
 end
+
+function plot_on_axis!(args...; kwargs...)
+    throw(
+        ArgumentError(
+            "plot_on_axis! requires PythonPlot.jl. " * "Run `using PythonPlot` first."
+        ),
+    )
+end
+
+function figure_publication(args...; kwargs...)
+    throw(
+        ArgumentError(
+            "figure_publication requires PythonPlot.jl. " * "Run `using PythonPlot` first."
+        ),
+    )
+end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -64,27 +64,41 @@ function plot_bands! end
 # These stubs only exist to provide docstrings and allow pre-declaration
 
 """
-    savefig_publication(bs::BandStructure, path; kwargs...)
-    savefig_publication(bss::AbstractVector{<:BandStructure}, path; kwargs...)
+    savefig_publication(bs::BandStructure, path; kwargs...) -> path
+    savefig_publication(bss::AbstractVector{<:BandStructure}, path; kwargs...) -> path
 
-Save a publication-quality band structure figure via the PythonPlot extension.
-Requires `using PythonPlot` to activate `PhoXonicPythonPlotExt`.
+Render a band structure (or a vector of them) to `path` and return `path`; the
+output format follows the file extension (`.pdf`, `.png`, `.svg`, …). This is the
+convenience entry point (the only exported layer): the single-`BandStructure`
+method delegates to [`figure_publication`](@ref) and closes the figure for you,
+while a vector is drawn panel-by-panel (or overlaid). Requires `using PythonPlot`
+to activate `PhoXonicPythonPlotExt`.
 
-The output format is inferred from the file extension (`.pdf`, `.png`, `.svg`, ...).
+# Arguments
 
-# Keyword arguments
+- `bs::BandStructure` / `bss::AbstractVector{<:BandStructure}`: the band structure(s) to plot
+- `path::AbstractString`: output file; the extension selects the format
 
-- `axis_width_cm = 8.0`, `axis_height_cm = 6.0` — Axis size in centimeters.
-- `ylims = nothing` — Y-axis range (auto if `nothing`).
-- `title = ""` — Plot title (suppressed if empty).
-- `show_gaps = false` — Shade band gaps with `axhspan`.
-- `normalize = 1.0` — Frequency normalization factor (forwarded to `band_plot_data`).
-- `layout = (1, length(bss))` — Subplot grid for the vector overload.
-- `overlay = false` — Plot all `bss` on a single axis (vector overload).
+# Keywords
+
+- `axis_width_mm=80.0`: plotting area width in mm
+- `axis_height_mm=60.0`: plotting area height in mm
+- `ylims=nothing`: pass a tuple to override the y axis limits
+- `title=""`: plot title (suppressed if empty)
+- `show_gaps=false`: shade band gaps with `axhspan`
+- `normalize=1.0`: frequency normalization factor (forwarded to `band_plot_data`)
+- `layout=(1, length(bss))`: subplot grid `(nrows, ncols)` (vector overload)
+- `overlay=false`: draw all band structures on a single axis (vector overload)
 
 See also: [`plot_bands`](@ref) for interactive plotting with Plots.jl.
 """
 function savefig_publication end
+
+# `plot_on_axis!` (L1) and `figure_publication` (L2) carry their per-method
+# docstrings in ext/PhoXonicPythonPlotExt.jl. The extension module is added to
+# Documenter's `modules` so `@docs` renders those docstrings.
+function plot_on_axis! end
+function figure_publication end
 
 """
     band_plot_data(bs::BandStructure; normalize=1.0)

--- a/test/test_publication.jl
+++ b/test/test_publication.jl
@@ -56,10 +56,10 @@ using StaticArrays
         end
     end
 
-    @testset "axis_width_cm / axis_height_cm カスタム" begin
+    @testset "axis_width_mm / axis_height_mm カスタム" begin
         mktempdir() do tmp
             path = joinpath(tmp, "custom_size.pdf")
-            savefig_publication(bs2, path; axis_width_cm=10.0, axis_height_cm=5.0)
+            savefig_publication(bs2, path; axis_width_mm=100.0, axis_height_mm=50.0)
             @test isfile(path)
         end
     end
@@ -126,5 +126,72 @@ using StaticArrays
             savefig_publication(bs2, path; ylabel="Frequency [THz]")
             @test isfile(path)
         end
+    end
+
+    @testset "L1 plot_on_axis!" begin
+        # returns ax, no exception, composes into a user subplot grid
+        mktempdir() do tmp
+            fig = PythonPlot.figure(; figsize=(8, 4))
+            ax1 = fig.add_subplot(1, 2, 1)
+            ax2 = fig.add_subplot(1, 2, 2)
+            @test PhoXonic.plot_on_axis!(ax1, bs2; title="TE") === ax1
+            PhoXonic.plot_on_axis!(ax2, bs2)
+            path = joinpath(tmp, "panel.pdf")
+            fig.savefig(path)
+            @test isfile(path)
+            PythonPlot.close(fig)
+        end
+        # title: non-empty applies, empty leaves no title
+        let fig = PythonPlot.figure()
+            ax = fig.add_subplot()
+            PhoXonic.plot_on_axis!(ax, bs2; title="MyBands")
+            @test occursin("MyBands", string(ax.get_title()))
+            PythonPlot.close(fig)
+        end
+        let fig = PythonPlot.figure()
+            ax = fig.add_subplot()
+            PhoXonic.plot_on_axis!(ax, bs2)
+            @test isempty(string(ax.get_title()))
+            PythonPlot.close(fig)
+        end
+        # xlabel absorbed by the wrapper (PhoXonic-specific noop resolved)
+        let fig = PythonPlot.figure()
+            ax = fig.add_subplot()
+            PhoXonic.plot_on_axis!(ax, bs2; xlabel="Wave vector")
+            @test occursin("Wave vector", string(ax.get_xlabel()))
+            PythonPlot.close(fig)
+        end
+        # PhoXonic-specific kwargs flow through L1 to the helper
+        let fig = PythonPlot.figure()
+            ax = fig.add_subplot()
+            @test PhoXonic.plot_on_axis!(ax, bs2; show_gaps=true, normalize=2.0) === ax
+            PythonPlot.close(fig)
+        end
+    end
+
+    @testset "L2 figure_publication" begin
+        res = PhoXonic.figure_publication(bs2)
+        @test res isa Tuple && length(res) == 2
+        fig, ax = res
+        @test fig isa PythonPlot.Figure
+        PythonPlot.close(fig)
+        # finalization kwarg (ylims) routed through L2
+        fig2, _ = PhoXonic.figure_publication(bs2; ylims=(0.0, 1.0))
+        PythonPlot.close(fig2)
+    end
+
+    @testset "L3 Vector overlay forwards kwargs" begin
+        mktempdir() do tmp
+            path = joinpath(tmp, "overlay_kw.pdf")
+            # overlay branch now forwards plot kwargs to L1 (previously dropped)
+            savefig_publication([bs2, bs2], path; overlay=true, show_gaps=true)
+            @test isfile(path)
+        end
+    end
+
+    @testset "L1/L2 fallback on bad-type args" begin
+        # ext loaded, but an unsupported type falls through to the untyped fallback
+        @test_throws ArgumentError PhoXonic.plot_on_axis!(nothing, nothing)
+        @test_throws ArgumentError PhoXonic.figure_publication(nothing)
     end
 end


### PR DESCRIPTION
Closes #60.

Add `plot_on_axis!(ax, bs)` and `figure_publication(bs)` (unexported) so figures can be composed onto a user axis or tweaked before saving. `savefig_publication` stays the exported one-call entry point and delegates through them.

BREAKING: axis sizes are now millimeters (`axis_width_mm` / `axis_height_mm`), not centimeters → v0.3.0.