### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhoXonic"
 uuid = "f8e5d5a0-1234-4567-89ab-cdef01234567"
 authors = ["Hiroharu Sugawara <hsugawa@gmail.com>"]
-version = "0.2.5"
+version = "0.3.0"
 
 [deps]
 Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"


### PR DESCRIPTION
Bump version to v0.3.0 for release (#62).

v0.3.0 adds the 3-layer PythonPlot API (`plot_on_axis!`, `figure_publication`, #61) and switches axis-size keywords from cm to mm (breaking).