### PR TITLE
docs: bump citation version to v0.3.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ repository-code: "https://github.com/hsugawa8651/PhoXonic.jl"
 url: "https://github.com/hsugawa8651/PhoXonic.jl"
 doi: "10.5281/zenodo.18055170"
 license: MIT
-version: 0.2.5
-date-released: 2026-05-03
+version: 0.3.0
+date-released: 2026-05-31
 keywords:
   - photonic crystals
   - phononic crystals

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you use PhoXonic.jl in your work, please cite:
   title        = {PhoXonic.jl: Photonic and Phononic Crystal Band Structure},
   year         = 2026,
   publisher    = {Zenodo},
-  version      = {v0.2.5},
+  version      = {v0.3.0},
   doi          = {10.5281/zenodo.18055170},
   url          = {https://doi.org/10.5281/zenodo.18055170}
 }

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -94,7 +94,7 @@ If you use PhoXonic.jl in your work, please cite:
   title        = {PhoXonic.jl: Photonic and Phononic Crystal Band Structure},
   year         = 2026,
   publisher    = {Zenodo},
-  version      = {v0.2.5},
+  version      = {v0.3.0},
   doi          = {10.5281/zenodo.18055170},
   url          = {https://doi.org/10.5281/zenodo.18055170}
 }


### PR DESCRIPTION
Closes #64.

Bump the citation version label to v0.3.0 in `README.md`, `docs/src/index.md`, and `CITATION.cff` (plus `date-released`). The Zenodo badge and citation DOI stay the concept DOI (`10.5281/zenodo.18055170`), which always resolves to the latest version.