### PR TITLE
style: apply JuliaFormatter v2 formatting

### DIFF
--- a/examples/214_maldovan2006_phoxonic.jl
+++ b/examples/214_maldovan2006_phoxonic.jl
@@ -211,7 +211,7 @@ function draw_circle!(p, cx, cy, r; color=:blue, fillalpha=1.0, n=100)
     θ = range(0, 2π; length=n)
     xs = cx .+ r .* cos.(θ)
     ys = cy .+ r .* sin.(θ)
-    plot!(
+    return plot!(
         p,
         xs,
         ys;

--- a/examples/511_supercell_study.jl
+++ b/examples/511_supercell_study.jl
@@ -255,29 +255,29 @@ function add_absorbing_layer_concept()
     # ε(x) = ε_real + i * σ(x) / ω
     # where σ(x) increases towards boundaries
 
-    println("""
-    # Pseudo-code for absorbing layer:
+    return println("""
+           # Pseudo-code for absorbing layer:
 
-    function create_pml_supercell(inner_geo, n_pml_layers, σ_max)
-        # 1. Create larger lattice with PML layers
-        total_x = inner_geo.size_x + 2 * n_pml_layers * a
-        total_y = inner_geo.size_y + 2 * n_pml_layers * a
+           function create_pml_supercell(inner_geo, n_pml_layers, σ_max)
+               # 1. Create larger lattice with PML layers
+               total_x = inner_geo.size_x + 2 * n_pml_layers * a
+               total_y = inner_geo.size_y + 2 * n_pml_layers * a
 
-        # 2. Copy inner inclusions
-        inclusions = copy_to_center(inner_geo.inclusions)
+               # 2. Copy inner inclusions
+               inclusions = copy_to_center(inner_geo.inclusions)
 
-        # 3. Add absorbing material at edges
-        for layer in 1:n_pml_layers
-            # Conductivity profile (polynomial grading)
-            σ = σ_max * (layer / n_pml_layers)^2
+               # 3. Add absorbing material at edges
+               for layer in 1:n_pml_layers
+                   # Conductivity profile (polynomial grading)
+                   σ = σ_max * (layer / n_pml_layers)^2
 
-            # Add absorbing elements at this layer distance from edge
-            # (Implementation depends on how complex ε is handled)
-        end
+                   # Add absorbing elements at this layer distance from edge
+                   # (Implementation depends on how complex ε is handled)
+               end
 
-        return Geometry(large_lattice, background, inclusions)
-    end
-    """)
+               return Geometry(large_lattice, background, inclusions)
+           end
+           """)
 end
 
 add_absorbing_layer_concept()

--- a/examples/801_plot_structures.jl
+++ b/examples/801_plot_structures.jl
@@ -23,7 +23,7 @@ function draw_circle!(p, cx, cy, r; color=:blue, fillalpha=1.0, n=100)
     θ = range(0, 2π; length=n)
     xs = cx .+ r .* cos.(θ)
     ys = cy .+ r .* sin.(θ)
-    plot!(
+    return plot!(
         p,
         xs,
         ys;

--- a/examples/901_mpb_benchmark.jl
+++ b/examples/901_mpb_benchmark.jl
@@ -100,7 +100,7 @@ idx_gamma2 = n_kpts
 # Extract TM frequencies
 # frequencies is (nk × nbands) matrix
 function get_frequencies_at_k(bands, idx)
-    bands.frequencies[idx, :]
+    return bands.frequencies[idx, :]
 end
 
 freq_tm_gamma = get_frequencies_at_k(bands_tm, idx_gamma1)

--- a/ext/PhoXonicMakieExt.jl
+++ b/ext/PhoXonicMakieExt.jl
@@ -571,7 +571,7 @@ function _get_component_index(::Type{<:WaveType}, component::Symbol)
     component in (:x, :first, :1) && return 1
     component in (:y, :second, :2) && return 2
     component in (:z, :third, :3) && return 3
-    error("Unknown component: $component")
+    return error("Unknown component: $component")
 end
 
 end # module

--- a/ext/PhoXonicPlotsExt.jl
+++ b/ext/PhoXonicPlotsExt.jl
@@ -214,7 +214,9 @@ function PhoXonic.plot_field(
     N = length(data)
     x = range(0, 1; length=N)
 
-    Plots.plot(x, data; xlabel=xlabel, ylabel=ylabel, title=title, legend=false, kwargs...)
+    return Plots.plot(
+        x, data; xlabel=xlabel, ylabel=ylabel, title=title, legend=false, kwargs...
+    )
 end
 
 # -----------------------------------------------------------------------------
@@ -263,7 +265,7 @@ function PhoXonic.plot_field(
     data = _extract_quantity(data_complex, quantity)
 
     # Transpose for correct orientation (x horizontal, y vertical)
-    Plots.heatmap(
+    return Plots.heatmap(
         data';
         c=colormap,
         title=title,
@@ -351,7 +353,7 @@ function PhoXonic.plot_epsilon(
     N = length(eps)
     x = range(0, 1; length=N)
 
-    Plots.plot(
+    return Plots.plot(
         x,
         eps;
         xlabel=xlabel,
@@ -382,7 +384,7 @@ function PhoXonic.plot_epsilon(
 )
     eps = get_epsilon_field(solver)
 
-    Plots.heatmap(
+    return Plots.heatmap(
         eps';
         c=colormap,
         title=title,
@@ -416,7 +418,7 @@ function _get_component_index(::Type{<:WaveType}, component::Symbol)
     component in (:x, :first, :1) && return 1
     component in (:y, :second, :2) && return 2
     component in (:z, :third, :3) && return 3
-    error("Unknown component: $component")
+    return error("Unknown component: $component")
 end
 
 end # module

--- a/ext/PhoXonicPythonPlotExt.jl
+++ b/ext/PhoXonicPythonPlotExt.jl
@@ -53,7 +53,7 @@ function _plot_bs_on_ax!(
     if !isempty(title)
         ax.set_title(title)
     end
-    ax.set_xlim(data.distances[1], data.distances[end])
+    return ax.set_xlim(data.distances[1], data.distances[end])
 end
 
 # ── L1: plot_on_axis! ──

--- a/src/bandstructure.jl
+++ b/src/bandstructure.jl
@@ -60,7 +60,7 @@ function find_bandgap(bs::BandStructure, band1::Int, band2::Int)
     midgap = (min_upper + max_lower) / 2
     gap_ratio = midgap > 0 ? gap / midgap : 0.0
 
-    (gap=gap, gap_ratio=gap_ratio, min_upper=min_upper, max_lower=max_lower)
+    return (gap=gap, gap_ratio=gap_ratio, min_upper=min_upper, max_lower=max_lower)
 end
 
 """
@@ -311,7 +311,7 @@ function compute_bands(
         end
     end
 
-    BandStructure{2}(kpath.points, kpath.distances, frequencies, kpath.labels)
+    return BandStructure{2}(kpath.points, kpath.distances, frequencies, kpath.labels)
 end
 
 function compute_bands(
@@ -344,7 +344,7 @@ function compute_bands(
         push!(distances, distances[end] + norm(points[i] - points[i - 1]))
     end
 
-    BandStructure{2}(points, distances, frequencies, Tuple{Int,String}[])
+    return BandStructure{2}(points, distances, frequencies, Tuple{Int,String}[])
 end
 
 function compute_bands(
@@ -383,7 +383,7 @@ function compute_bands(
     # Extract labels from KPathInterpolant if available
     labels = Tuple{Int,String}[]
 
-    BandStructure{2}(kpoints, distances, frequencies, labels)
+    return BandStructure{2}(kpoints, distances, frequencies, labels)
 end
 
 # ============================================================================
@@ -442,7 +442,7 @@ function compute_bands(
         end
     end
 
-    BandStructure{3}(kpath.points, kpath.distances, frequencies, kpath.labels)
+    return BandStructure{3}(kpath.points, kpath.distances, frequencies, kpath.labels)
 end
 
 function compute_bands(
@@ -475,7 +475,7 @@ function compute_bands(
         push!(distances, distances[end] + norm(points[i] - points[i - 1]))
     end
 
-    BandStructure{3}(points, distances, frequencies, Tuple{Int,String}[])
+    return BandStructure{3}(points, distances, frequencies, Tuple{Int,String}[])
 end
 
 function compute_bands(
@@ -513,7 +513,7 @@ function compute_bands(
     # Extract labels from KPathInterpolant if available
     labels = Tuple{Int,String}[]
 
-    BandStructure{3}(kpoints, distances, frequencies, labels)
+    return BandStructure{3}(kpoints, distances, frequencies, labels)
 end
 
 # ============================================================================
@@ -528,7 +528,7 @@ Compute band structure along a k-path.
 See concrete method signatures for detailed documentation and keyword arguments.
 """
 function compute_bands(solver::Any, kpath::Any; kwargs...)
-    error(
+    return error(
         "compute_bands: expected (solver::Solver, kpath), " *
         "got ($(typeof(solver)), $(typeof(kpath)))",
     )

--- a/src/convmat.jl
+++ b/src/convmat.jl
@@ -133,5 +133,5 @@ Compute the convolution matrix of 1/f.
 Useful for TM modes where we need ε⁻¹.
 """
 function inverse_convolution_matrix(f::AbstractArray, basis::PlaneWaveBasis)
-    convolution_matrix(1.0 ./ f, basis)
+    return convolution_matrix(1.0 ./ f, basis)
 end

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -1,7 +1,7 @@
 # Fallback errors for extension-dependent functions
 
 function savefig_publication(args...; kwargs...)
-    throw(
+    return throw(
         ArgumentError(
             "savefig_publication requires PythonPlot.jl. " * "Run `using PythonPlot` first."
         ),
@@ -9,7 +9,7 @@ function savefig_publication(args...; kwargs...)
 end
 
 function plot_on_axis!(args...; kwargs...)
-    throw(
+    return throw(
         ArgumentError(
             "plot_on_axis! requires PythonPlot.jl. " * "Run `using PythonPlot` first."
         ),
@@ -17,7 +17,7 @@ function plot_on_axis!(args...; kwargs...)
 end
 
 function figure_publication(args...; kwargs...)
-    throw(
+    return throw(
         ArgumentError(
             "figure_publication requires PythonPlot.jl. " * "Run `using PythonPlot` first."
         ),

--- a/src/field.jl
+++ b/src/field.jl
@@ -121,7 +121,7 @@ function _reconstruct_vector_field(
         coeffs = ComplexF64.(eigenvector[start_idx:end_idx])
         grid = zeros(ComplexF64, Nx, Ny)
         fourier_to_grid!(grid, coeffs, solver.basis, resolution)
-        grid
+        return grid
     end
 
     return fields
@@ -146,7 +146,7 @@ function _reconstruct_vector_field(
         coeffs = ComplexF64.(eigenvector[start_idx:end_idx])
         grid = zeros(ComplexF64, Nx, Ny, Nz)
         fourier_to_grid!(grid, coeffs, solver.basis, resolution)
-        grid
+        return grid
     end
 
     return fields

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -34,7 +34,7 @@ end
 Create a homogeneous geometry with no inclusions.
 """
 function Geometry(lattice::Lattice{D}, background::M) where {D<:Dimension,M<:Material}
-    Geometry{D,M}(lattice, background, Tuple{Shape{D},M}[])
+    return Geometry{D,M}(lattice, background, Tuple{Shape{D},M}[])
 end
 
 """
@@ -48,7 +48,7 @@ function Geometry(
     # Ensure all materials have compatible types
     MT = promote_type(M, M2)
     incl = Vector{Tuple{Shape{D},MT}}([(s, convert(MT, m)) for (s, m) in inclusions])
-    Geometry{D,MT}(lattice, convert(MT, background), incl)
+    return Geometry{D,MT}(lattice, convert(MT, background), incl)
 end
 
 # Helper to extract dimension type from Shape
@@ -82,7 +82,7 @@ function Geometry(
     # If dimensions all match, use promote_type for mixed materials
     MT = promote_type(M, M2)
     typed_incl = Vector{Tuple{Shape{D},MT}}([(s, convert(MT, m)) for (s, m) in inclusions])
-    Geometry{D,MT}(lattice, convert(MT, background), typed_incl)
+    return Geometry{D,MT}(lattice, convert(MT, background), typed_incl)
 end
 
 """
@@ -141,7 +141,7 @@ function point_in_shape_periodic(point::Vec2, c::Circle, lattice::Lattice{Dim2})
 end
 
 function point_in_shape_periodic(point::AbstractVector, c::Circle, lattice::Lattice{Dim2})
-    point_in_shape_periodic(Vec2(point...), c, lattice)
+    return point_in_shape_periodic(Vec2(point...), c, lattice)
 end
 
 # Rectangle: wrap point relative to rectangle center
@@ -168,7 +168,7 @@ end
 function point_in_shape_periodic(
     point::AbstractVector, r::Rectangle, lattice::Lattice{Dim2}
 )
-    point_in_shape_periodic(Vec2(point...), r, lattice)
+    return point_in_shape_periodic(Vec2(point...), r, lattice)
 end
 
 # Ellipse: check if point is in ellipse or any periodic image
@@ -189,7 +189,7 @@ function point_in_shape_periodic(point::Vec2, e::Ellipse, lattice::Lattice{Dim2}
 end
 
 function point_in_shape_periodic(point::AbstractVector, e::Ellipse, lattice::Lattice{Dim2})
-    point_in_shape_periodic(Vec2(point...), e, lattice)
+    return point_in_shape_periodic(Vec2(point...), e, lattice)
 end
 
 # Polygon: check if point is in polygon or any periodic image
@@ -212,7 +212,7 @@ end
 function point_in_shape_periodic(
     point::AbstractVector, poly::Polygon, lattice::Lattice{Dim2}
 )
-    point_in_shape_periodic(Vec2(point...), poly, lattice)
+    return point_in_shape_periodic(Vec2(point...), poly, lattice)
 end
 
 # 3D Sphere: wrap point relative to sphere center
@@ -238,7 +238,7 @@ function point_in_shape_periodic(point::Vec3, s::Sphere, lattice::Lattice{Dim3})
 end
 
 function point_in_shape_periodic(point::AbstractVector, s::Sphere, lattice::Lattice{Dim3})
-    point_in_shape_periodic(Vec3(point...), s, lattice)
+    return point_in_shape_periodic(Vec3(point...), s, lattice)
 end
 
 # 3D Cylinder: check all periodic images
@@ -263,7 +263,7 @@ end
 function point_in_shape_periodic(
     point::AbstractVector, cyl::Cylinder, lattice::Lattice{Dim3}
 )
-    point_in_shape_periodic(Vec3(point...), cyl, lattice)
+    return point_in_shape_periodic(Vec3(point...), cyl, lattice)
 end
 
 # 3D Slab: only check z-direction periodic images (infinite in xy)
@@ -282,7 +282,7 @@ function point_in_shape_periodic(point::Vec3, slab::Slab, lattice::Lattice{Dim3}
 end
 
 function point_in_shape_periodic(point::AbstractVector, slab::Slab, lattice::Lattice{Dim3})
-    point_in_shape_periodic(Vec3(point...), slab, lattice)
+    return point_in_shape_periodic(Vec3(point...), slab, lattice)
 end
 
 # ============================================================================
@@ -336,7 +336,7 @@ function discretize(
     property::Symbol,
     method::DiscretizationMethod=SimpleGrid(),
 )
-    discretize_impl(geo, resolution, property, method)
+    return discretize_impl(geo, resolution, property, method)
 end
 
 function discretize_impl(
@@ -397,7 +397,7 @@ Extract a specific property from a material.
 """
 # Error fallback for unsupported material types
 function get_property(mat, property::Symbol)
-    throw(ArgumentError("Unsupported material type: $(typeof(mat))"))
+    return throw(ArgumentError("Unsupported material type: $(typeof(mat))"))
 end
 
 function get_property(mat::Dielectric, property::Symbol)
@@ -457,7 +457,7 @@ function discretize(
     property::Symbol,
     method::DiscretizationMethod=SimpleGrid(),
 )
-    discretize_impl(geo, resolution, property, method)
+    return discretize_impl(geo, resolution, property, method)
 end
 
 # Also accept Int directly for 1D
@@ -467,7 +467,7 @@ function discretize(
     property::Symbol,
     method::DiscretizationMethod=SimpleGrid(),
 )
-    discretize_impl(geo, (resolution,), property, method)
+    return discretize_impl(geo, (resolution,), property, method)
 end
 
 function discretize_impl(
@@ -574,7 +574,7 @@ function discretize(
     property::Symbol,
     method::DiscretizationMethod=SimpleGrid(),
 )
-    discretize_impl(geo, resolution, property, method)
+    return discretize_impl(geo, resolution, property, method)
 end
 
 function discretize_impl(
@@ -676,7 +676,7 @@ Discretize geometry on a grid.
 See concrete method signatures for detailed documentation and keyword arguments.
 """
 function discretize(geometry::Any, args...; kwargs...)
-    error(
+    return error(
         "discretize: expected geometry::Geometry as first argument, " *
         "got $(typeof(geometry))",
     )
@@ -685,7 +685,7 @@ end
 # Error fallback for invalid Geometry constructor arguments
 function Geometry(args...)
     arg_types = isempty(args) ? "()" : "(" * join(typeof.(args), ", ") * ")"
-    error(
+    return error(
         "No matching Geometry constructor for arguments: $arg_types. " *
         "Use Geometry(lattice, background) or Geometry(lattice, background, inclusions).",
     )

--- a/src/io.jl
+++ b/src/io.jl
@@ -79,7 +79,7 @@ function save_bands(
         file["kpoints"] = bands.kpoints
         file["distances"] = bands.distances
         file["labels"] = bands.labels
-        file["metadata"] = meta
+        return file["metadata"] = meta
     end
 
     return filename
@@ -216,7 +216,7 @@ end
 
 # Error fallback for unsupported wave types
 function _save_material_arrays!(file, wave, mats)
-    throw(ArgumentError("Unsupported wave type for save_epsilon: $(typeof(wave))"))
+    return throw(ArgumentError("Unsupported wave type for save_epsilon: $(typeof(wave))"))
 end
 
 # Fallback for all PhotonicWave (TEWave, TMWave, Photonic1D)
@@ -302,7 +302,7 @@ function save_epsilon(
         file["metadata"] = meta
 
         # Save based on wave type (uses multiple dispatch)
-        _save_material_arrays!(file, wave, mats)
+        return _save_material_arrays!(file, wave, mats)
     end
 
     return filename

--- a/src/kpath.jl
+++ b/src/kpath.jl
@@ -141,7 +141,7 @@ function SimpleKPath(
         end
     end
 
-    SimpleKPath{D}(all_points, all_labels, all_distances)
+    return SimpleKPath{D}(all_points, all_labels, all_distances)
 end
 
 """
@@ -156,7 +156,7 @@ function simple_kpath_square(; a::Real=1.0, npoints::Int=50)
     X = [0.5 * scale, 0.0]
     M = [0.5 * scale, 0.5 * scale]
 
-    SimpleKPath([Γ, X, M, Γ], ["Γ", "X", "M", "Γ"]; npoints=npoints)
+    return SimpleKPath([Γ, X, M, Γ], ["Γ", "X", "M", "Γ"]; npoints=npoints)
 end
 
 """
@@ -174,7 +174,7 @@ function simple_kpath_hexagonal(; a::Real=1.0, npoints::Int=50)
     M = collect(0.5 * b1)
     K = collect((1.0 / 3.0) * b1 + (1.0 / 3.0) * b2)
 
-    SimpleKPath([Γ, M, K, Γ], ["Γ", "M", "K", "Γ"]; npoints=npoints)
+    return SimpleKPath([Γ, M, K, Γ], ["Γ", "M", "K", "Γ"]; npoints=npoints)
 end
 
 # Iteration interface for SimpleKPath
@@ -337,7 +337,7 @@ function simple_kpath_cubic(; a::Real=1.0, npoints::Int=50)
     M = [0.5 * scale, 0.5 * scale, 0.0]
     R = [0.5 * scale, 0.5 * scale, 0.5 * scale]
 
-    SimpleKPath([Γ, X, M, Γ, R, X], ["Γ", "X", "M", "Γ", "R", "X"]; npoints=npoints)
+    return SimpleKPath([Γ, X, M, Γ, R, X], ["Γ", "X", "M", "Γ", "R", "X"]; npoints=npoints)
 end
 
 """
@@ -381,7 +381,7 @@ function simple_kpath_fcc(; a::Real=1.0, npoints::Int=50)
     L = [0.5 * scale, 0.5 * scale, 0.5 * scale]  # (1/2, 1/2, 1/2) × 2π/a
     K = [0.75 * scale, 0.75 * scale, 0.0]        # (3/4, 3/4, 0) × 2π/a
 
-    SimpleKPath([Γ, X, W, L, Γ, K], ["Γ", "X", "W", "L", "Γ", "K"]; npoints=npoints)
+    return SimpleKPath([Γ, X, W, L, Γ, K], ["Γ", "X", "W", "L", "Γ", "K"]; npoints=npoints)
 end
 
 """
@@ -417,7 +417,9 @@ function kpath_fcc_joannopoulos(; a::Real=1.0, npoints::Int=15)
     L = [0.5 * scale, 0.5 * scale, 0.5 * scale]  # (1/2, 1/2, 1/2) × 2π/a
 
     # Path: X → U|K → Γ → X → W → K (Joannopoulos style)
-    SimpleKPath([X, U, Γ, X, W, K], ["X", "U|K", "Γ", "X", "W", "K"]; npoints=npoints)
+    return SimpleKPath(
+        [X, U, Γ, X, W, K], ["X", "U|K", "Γ", "X", "W", "K"]; npoints=npoints
+    )
 end
 
 """
@@ -456,5 +458,5 @@ function simple_kpath_bcc(; a::Real=1.0, npoints::Int=50)
     N = [0.0, 0.5 * scale, 0.5 * scale]
     P = [0.25 * scale, 0.25 * scale, 0.25 * scale]
 
-    SimpleKPath([Γ, H, N, Γ, P, H], ["Γ", "H", "N", "Γ", "P", "H"]; npoints=npoints)
+    return SimpleKPath([Γ, H, N, Γ, P, H], ["Γ", "H", "N", "Γ", "P", "H"]; npoints=npoints)
 end

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -30,7 +30,7 @@ Create a 1D lattice with period `a`.
 function Lattice(a::Real)
     v = (Vec1(a),)
     r = (Vec1(2π / a),)
-    Lattice{Dim1}(v, r)
+    return Lattice{Dim1}(v, r)
 end
 
 # ============================================================================
@@ -49,7 +49,7 @@ function Lattice(a1::Vec2, a2::Vec2)
     V = a1[1] * a2[2] - a1[2] * a2[1]  # Area of unit cell
     b1 = (2π / V) * Vec2(a2[2], -a2[1])
     b2 = (2π / V) * Vec2(-a1[2], a1[1])
-    Lattice{Dim2}((a1, a2), (b1, b2))
+    return Lattice{Dim2}((a1, a2), (b1, b2))
 end
 
 """
@@ -58,7 +58,7 @@ end
 Create a 2D lattice from any vector types (converted to Vec2).
 """
 function Lattice(a1::AbstractVector, a2::AbstractVector)
-    Lattice(Vec2(a1...), Vec2(a2...))
+    return Lattice(Vec2(a1...), Vec2(a2...))
 end
 
 # ============================================================================
@@ -77,7 +77,7 @@ function Lattice(a1::Vec3, a2::Vec3, a3::Vec3)
     b1 = (2π / V) * cross(a2, a3)
     b2 = (2π / V) * cross(a3, a1)
     b3 = (2π / V) * cross(a1, a2)
-    Lattice{Dim3}((a1, a2, a3), (b1, b2, b3))
+    return Lattice{Dim3}((a1, a2, a3), (b1, b2, b3))
 end
 
 # ============================================================================
@@ -97,7 +97,7 @@ lattice_1d(a::Real=1.0) = Lattice(Float64(a))
 Create a 2D square lattice with lattice constant `a`.
 """
 function square_lattice(a::Real=1.0)
-    Lattice(Vec2(a, 0), Vec2(0, a))
+    return Lattice(Vec2(a, 0), Vec2(0, a))
 end
 
 """
@@ -106,7 +106,7 @@ end
 Create a 2D hexagonal (triangular) lattice with lattice constant `a`.
 """
 function hexagonal_lattice(a::Real=1.0)
-    Lattice(Vec2(a, 0), Vec2(a / 2, a * sqrt(3) / 2))
+    return Lattice(Vec2(a, 0), Vec2(a / 2, a * sqrt(3) / 2))
 end
 
 """
@@ -115,7 +115,7 @@ end
 Create a 3D simple cubic lattice with lattice constant `a`.
 """
 function cubic_lattice(a::Real=1.0)
-    Lattice(Vec3(a, 0, 0), Vec3(0, a, 0), Vec3(0, 0, a))
+    return Lattice(Vec3(a, 0, 0), Vec3(0, a, 0), Vec3(0, 0, a))
 end
 
 """
@@ -124,7 +124,7 @@ end
 Create a 3D face-centered cubic lattice with conventional lattice constant `a`.
 """
 function fcc_lattice(a::Real=1.0)
-    Lattice(Vec3(0, a/2, a/2), Vec3(a/2, 0, a/2), Vec3(a/2, a/2, 0))
+    return Lattice(Vec3(0, a/2, a/2), Vec3(a/2, 0, a/2), Vec3(a/2, a/2, 0))
 end
 
 # ============================================================================
@@ -152,7 +152,7 @@ Return the area of the 2D unit cell.
 """
 function cell_area(lattice::Lattice{Dim2})
     a1, a2 = lattice.vectors
-    abs(a1[1] * a2[2] - a1[2] * a2[1])
+    return abs(a1[1] * a2[2] - a1[2] * a2[1])
 end
 
 """
@@ -162,13 +162,13 @@ Return the volume of the 3D unit cell.
 """
 function cell_volume(lattice::Lattice{Dim3})
     a1, a2, a3 = lattice.vectors
-    abs(dot(a1, cross(a2, a3)))
+    return abs(dot(a1, cross(a2, a3)))
 end
 
 # Error fallback for invalid constructor arguments
 function Lattice(args...)
     arg_types = isempty(args) ? "()" : "(" * join(typeof.(args), ", ") * ")"
-    error(
+    return error(
         "No matching Lattice constructor for arguments: $arg_types. " *
         "Use Lattice(a::Real) for 1D, Lattice(a1, a2) for 2D, or Lattice(a1, a2, a3) for 3D.",
     )

--- a/src/material.jl
+++ b/src/material.jl
@@ -118,7 +118,7 @@ refractive_index(m::LossyDielectric) = sqrt(m.ε * m.μ)
 
 # Type conversion: Dielectric → LossyDielectric
 function Base.convert(::Type{LossyDielectric}, d::Dielectric)
-    LossyDielectric(ComplexF64(d.ε), ComplexF64(d.μ))
+    return LossyDielectric(ComplexF64(d.ε), ComplexF64(d.μ))
 end
 
 # Type promotion rules
@@ -163,7 +163,7 @@ end
 Create isotropic elastic material from Lamé parameters.
 """
 function IsotropicElastic(; ρ::Real, λ::Real, μ::Real)
-    IsotropicElastic(Float64(ρ), Float64(λ + 2μ), Float64(λ), Float64(μ))
+    return IsotropicElastic(Float64(ρ), Float64(λ + 2μ), Float64(λ), Float64(μ))
 end
 
 """
@@ -174,7 +174,7 @@ Create isotropic elastic material from Young's modulus `E` and Poisson's ratio `
 function from_E_ν(ρ::Real, E::Real, ν::Real)
     λ = E * ν / ((1 + ν) * (1 - 2ν))
     μ = E / (2 * (1 + ν))
-    IsotropicElastic(; ρ=ρ, λ=λ, μ=μ)
+    return IsotropicElastic(; ρ=ρ, λ=λ, μ=μ)
 end
 
 """
@@ -247,7 +247,7 @@ function ElasticVoid(; ρ_ratio::Real=1e-7)
     μ = 1.0
     λ = 1.0
     ρ = ρ_ratio * μ  # Small density for Tanaka limit
-    ElasticVoid(Float64(ρ), Float64(λ + 2μ), Float64(λ), Float64(μ))
+    return ElasticVoid(Float64(ρ), Float64(λ + 2μ), Float64(λ), Float64(μ))
 end
 
 """
@@ -294,7 +294,7 @@ Base.convert(::Type{ElasticMaterial}, x::ElasticVoid) = x
 # Error fallback for invalid Dielectric constructor arguments
 function Dielectric(args...)
     arg_types = isempty(args) ? "()" : "(" * join(typeof.(args), ", ") * ")"
-    error(
+    return error(
         "No matching Dielectric constructor for arguments: $arg_types. " *
         "Use Dielectric(ε::Real) or Dielectric(ε::Real, μ::Real).",
     )

--- a/src/matrixfree.jl
+++ b/src/matrixfree.jl
@@ -82,7 +82,9 @@ function FFTContext(resolution::NTuple{N,Int}, (::Type{T})=ComplexF64) where {N,
     work = zeros(T, resolution)
     fft_plan = plan_fft!(work)
     ifft_plan = plan_ifft!(work)
-    FFTContext{N,T,typeof(fft_plan),typeof(ifft_plan)}(resolution, fft_plan, ifft_plan)
+    return FFTContext{N,T,typeof(fft_plan),typeof(ifft_plan)}(
+        resolution, fft_plan, ifft_plan
+    )
 end
 
 """
@@ -115,7 +117,7 @@ Create workspace arrays for the given resolution.
 function MatrixFreeWorkspace(
     resolution::NTuple{N,Int}, (::Type{T})=ComplexF64
 ) where {N,T<:Complex}
-    MatrixFreeWorkspace{N,T}(zeros(T, resolution), zeros(T, resolution))
+    return MatrixFreeWorkspace{N,T}(zeros(T, resolution), zeros(T, resolution))
 end
 
 """
@@ -124,7 +126,7 @@ end
 Create workspace arrays matching the FFT context.
 """
 function MatrixFreeWorkspace(ctx::FFTContext{N,T,F,I}) where {N,T,F,I}
-    MatrixFreeWorkspace(ctx.resolution, T)
+    return MatrixFreeWorkspace(ctx.resolution, T)
 end
 
 # ============================================================================
@@ -193,7 +195,7 @@ function MatrixFreeOperator(
     ctx::FFTContext{N,T,F,I},
     workspace::MatrixFreeWorkspace{N,T},
 ) where {D<:Dimension,W<:WaveType,N,T,F,I}
-    MatrixFreeOperator{D,W,T,N,F,I}(solver, k, ctx, workspace)
+    return MatrixFreeOperator{D,W,T,N,F,I}(solver, k, ctx, workspace)
 end
 
 function MatrixFreeOperator(
@@ -202,7 +204,7 @@ function MatrixFreeOperator(
     ctx::FFTContext{1,T,F,I},
     workspace::MatrixFreeWorkspace{1,T},
 ) where {W<:WaveType,T,F,I}
-    MatrixFreeOperator{Dim1,W,T,1,F,I}(solver, [Float64(k)], ctx, workspace)
+    return MatrixFreeOperator{Dim1,W,T,1,F,I}(solver, [Float64(k)], ctx, workspace)
 end
 
 """
@@ -214,24 +216,24 @@ For better performance in loops, create `FFTContext` once and reuse.
 function MatrixFreeOperator(solver::Solver{Dim2,W}, k::Vector{Float64}) where {W<:WaveType}
     ctx = FFTContext(solver.resolution, ComplexF64)
     workspace = MatrixFreeWorkspace(ctx)
-    MatrixFreeOperator(solver, k, ctx, workspace)
+    return MatrixFreeOperator(solver, k, ctx, workspace)
 end
 
 function MatrixFreeOperator(solver::Solver{Dim1,W}, k::Real) where {W<:WaveType}
     ctx = FFTContext(solver.resolution, ComplexF64)
     workspace = MatrixFreeWorkspace(ctx)
-    MatrixFreeOperator(solver, Float64(k), ctx, workspace)
+    return MatrixFreeOperator(solver, Float64(k), ctx, workspace)
 end
 
 # 1D convenience constructor accepting Vector{Float64} (for compatibility with solve interface)
 function MatrixFreeOperator(solver::Solver{Dim1,W}, k::Vector{Float64}) where {W<:WaveType}
-    MatrixFreeOperator(solver, k[1])
+    return MatrixFreeOperator(solver, k[1])
 end
 
 function MatrixFreeOperator(solver::Solver{Dim3,W}, k::Vector{Float64}) where {W<:WaveType}
     ctx = FFTContext(solver.resolution, ComplexF64)
     workspace = MatrixFreeWorkspace(ctx)
-    MatrixFreeOperator(solver, k, ctx, workspace)
+    return MatrixFreeOperator(solver, k, ctx, workspace)
 end
 
 # ============================================================================
@@ -1044,7 +1046,7 @@ function to_linear_map_lhs(op::MatrixFreeOperator{D,W}) where {D,W}
     N = op.solver.basis.num_pw
     nc = ncomponents(op.solver.wave)
     dim = N * nc
-    LinearMap{ComplexF64}(
+    return LinearMap{ComplexF64}(
         x -> begin
             y = zeros(ComplexF64, dim)
             apply_lhs!(y, op, x)
@@ -1062,7 +1064,7 @@ function to_linear_map_rhs(op::MatrixFreeOperator{D,W}) where {D,W}
     N = op.solver.basis.num_pw
     nc = ncomponents(op.solver.wave)
     dim = N * nc
-    LinearMap{ComplexF64}(
+    return LinearMap{ComplexF64}(
         x -> begin
             y = zeros(ComplexF64, dim)
             apply_rhs!(y, op, x)
@@ -1272,7 +1274,7 @@ Create a shifted operator representing `(A - σB)`.
 function ShiftedOperator(op::MatrixFreeOperator{D,W,T,N,F,I}, σ::Real) where {D,W,T,N,F,I}
     dim = op.solver.basis.num_pw * ncomponents(op.solver.wave)
     tmp = zeros(T, dim)
-    ShiftedOperator{D,W,T,N,F,I}(op, Float64(σ), tmp)
+    return ShiftedOperator{D,W,T,N,F,I}(op, Float64(σ), tmp)
 end
 
 Base.size(S::ShiftedOperator) = (length(S.tmp), length(S.tmp))
@@ -1316,5 +1318,5 @@ Create a LinearMap representing `(A - σB)` for use with iterative solvers.
 function to_linear_map_shifted(op::MatrixFreeOperator{D,W}, σ::Real) where {D,W}
     S = ShiftedOperator(op, σ)
     dim = length(S.tmp)
-    LinearMap{ComplexF64}(x -> S * x, dim; ismutating=false, ishermitian=true)
+    return LinearMap{ComplexF64}(x -> S * x, dim; ismutating=false, ishermitian=true)
 end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -193,7 +193,7 @@ function KrylovKitMethod(;
     shift::Real=0.0,
     matrix_free::Bool=false,
 )
-    KrylovKitMethod(
+    return KrylovKitMethod(
         Float64(tol), maxiter, krylovdim, verbosity, Float64(shift), matrix_free
     )
 end
@@ -297,7 +297,7 @@ function LOBPCGMethod(;
     first_dense::Bool=true,
     preconditioner=:none,
 )
-    LOBPCGMethod(
+    return LOBPCGMethod(
         Float64(tol),
         maxiter,
         Float64(shift),

--- a/src/planewave.jl
+++ b/src/planewave.jl
@@ -44,7 +44,7 @@ function PlaneWaveBasis(lattice::Lattice{Dim1}, cutoff::Int)
         push!(G_vectors, p * b1)
     end
 
-    PlaneWaveBasis{Dim1}(lattice, cutoff, indices, G_vectors, length(indices))
+    return PlaneWaveBasis{Dim1}(lattice, cutoff, indices, G_vectors, length(indices))
 end
 
 # ============================================================================
@@ -72,7 +72,7 @@ function PlaneWaveBasis(lattice::Lattice{Dim2}, cutoff::Int)
         end
     end
 
-    PlaneWaveBasis{Dim2}(lattice, cutoff, indices, G_vectors, length(indices))
+    return PlaneWaveBasis{Dim2}(lattice, cutoff, indices, G_vectors, length(indices))
 end
 
 """
@@ -93,7 +93,7 @@ function PlaneWaveBasis(lattice::Lattice{Dim2}, cutoff_p::Int, cutoff_q::Int)
         end
     end
 
-    PlaneWaveBasis{Dim2}(
+    return PlaneWaveBasis{Dim2}(
         lattice, max(cutoff_p, cutoff_q), indices, G_vectors, length(indices)
     )
 end
@@ -124,7 +124,7 @@ function PlaneWaveBasis(lattice::Lattice{Dim3}, cutoff::Int)
         end
     end
 
-    PlaneWaveBasis{Dim3}(lattice, cutoff, indices, G_vectors, length(indices))
+    return PlaneWaveBasis{Dim3}(lattice, cutoff, indices, G_vectors, length(indices))
 end
 
 # ============================================================================
@@ -137,7 +137,7 @@ end
 Create a dictionary mapping indices to their position in the basis.
 """
 function index_map(basis::PlaneWaveBasis)
-    Dict(idx => i for (i, idx) in enumerate(basis.indices))
+    return Dict(idx => i for (i, idx) in enumerate(basis.indices))
 end
 
 """
@@ -159,7 +159,7 @@ Base.length(basis::PlaneWaveBasis) = basis.num_pw
 # Error fallback for invalid PlaneWaveBasis constructor arguments
 function PlaneWaveBasis(args...)
     arg_types = isempty(args) ? "()" : "(" * join(typeof.(args), ", ") * ")"
-    error(
+    return error(
         "No matching PlaneWaveBasis constructor for arguments: $arg_types. " *
         "Use PlaneWaveBasis(lattice, cutoff).",
     )

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -123,7 +123,7 @@ function band_plot_data(bs::BandStructure; normalize::Real=1.0)
         push!(label_names, name)
     end
 
-    (
+    return (
         distances=dists,
         frequencies=freqs,
         label_positions=label_positions,

--- a/src/rscg.jl
+++ b/src/rscg.jl
@@ -105,7 +105,7 @@ struct CGRHSInv <: RHSInvMethod
     maxiter::Int
 end
 function CGRHSInv(; atol::Float64=1e-10, rtol::Float64=1e-10, maxiter::Int=100)
-    CGRHSInv(atol, rtol, maxiter)
+    return CGRHSInv(atol, rtol, maxiter)
 end
 
 # Conversion from Symbol (deprecated, for backward compatibility)
@@ -126,7 +126,7 @@ _convert_rhs_inv_method(method::RHSInvMethod) = method
 
 # Error fallback for unsupported types
 function _convert_rhs_inv_method(method)
-    throw(
+    return throw(
         ArgumentError(
             "Unsupported rhs_inv_method type: $(typeof(method)). Use ApproximateRHSInv() or CGRHSInv().",
         ),
@@ -187,7 +187,7 @@ function compute_greens_function(
     source::AbstractVector;
     η::Real=1e-3,
 )
-    compute_greens_function(op.solver, op.k, ω_values, source; η=η)
+    return compute_greens_function(op.solver, op.k, ω_values, source; η=η)
 end
 
 # ============================================================================
@@ -477,7 +477,7 @@ function EffectiveHamiltonian(LHS::AbstractMatrix{T}, RHS::AbstractMatrix{T}) wh
     @assert size(LHS) == size(RHS) == (n, n) "LHS and RHS must be square and same size"
     RHS_fact = lu(RHS)
     tmp = Vector{T}(undef, n)
-    EffectiveHamiltonian(LHS, RHS, RHS_fact, n, tmp)
+    return EffectiveHamiltonian(LHS, RHS, RHS_fact, n, tmp)
 end
 
 """
@@ -487,7 +487,7 @@ Create an EffectiveHamiltonian from a PhoXonic Solver at wave vector k.
 """
 function EffectiveHamiltonian(solver::Solver, k)
     LHS, RHS = build_matrices(solver, k)
-    EffectiveHamiltonian(Matrix(LHS), Matrix(RHS))
+    return EffectiveHamiltonian(Matrix(LHS), Matrix(RHS))
 end
 
 # Size interface for LinearMaps compatibility
@@ -666,7 +666,7 @@ function MatrixFreeEffectiveHamiltonian(
     tmp_fourier2 = zeros(T, n)
     tmp_grid = zeros(T, res)
 
-    MatrixFreeEffectiveHamiltonian{D,W,T,N,F,I,typeof(rhs_inv_method)}(
+    return MatrixFreeEffectiveHamiltonian{D,W,T,N,F,I,typeof(rhs_inv_method)}(
         op, rhs_inv, tmp_fourier, tmp_fourier2, tmp_grid, n, rhs_inv_method
     )
 end
@@ -690,33 +690,33 @@ function MatrixFreeEffectiveHamiltonian(
     else
         throw(ArgumentError("rhs_inv_method must be :approximate or :cg"))
     end
-    MatrixFreeEffectiveHamiltonian(op, method)
+    return MatrixFreeEffectiveHamiltonian(op, method)
 end
 
 # Helper to get 1/RHS material array
 # Error fallback for unsupported wave types
 function _get_rhs_inv(wave::WaveType, mats, res, ::Type{T}) where {T}
-    throw(ArgumentError("Unsupported wave type for _get_rhs_inv: $(typeof(wave))"))
+    return throw(ArgumentError("Unsupported wave type for _get_rhs_inv: $(typeof(wave))"))
 end
 
 function _get_rhs_inv(::TEWave, mats, res, ::Type{T}) where {T}
     # TE: RHS = μ
-    T.(1.0 ./ mats.μ)
+    return T.(1.0 ./ mats.μ)
 end
 
 function _get_rhs_inv(::TMWave, mats, res, ::Type{T}) where {T}
     # TM: RHS = ε
-    T.(1.0 ./ mats.ε)
+    return T.(1.0 ./ mats.ε)
 end
 
 function _get_rhs_inv(::SHWave, mats, res, ::Type{T}) where {T}
     # SH: RHS = ρ
-    T.(1.0 ./ mats.ρ)
+    return T.(1.0 ./ mats.ρ)
 end
 
 function _get_rhs_inv(::PSVWave, mats, res, ::Type{T}) where {T}
     # PSV: RHS = ρ (same for both components)
-    T.(1.0 ./ mats.ρ)
+    return T.(1.0 ./ mats.ρ)
 end
 
 # Size interface
@@ -745,12 +745,12 @@ end
 function _apply_rhs_inv!(
     y::AbstractVector{T}, H::MatrixFreeEffectiveHamiltonian{Dim2,W,T}, x::AbstractVector{T}
 ) where {W<:WaveType,T}
-    _apply_rhs_inv_impl!(wave_structure(W()), H.rhs_inv_method, y, H, x)
+    return _apply_rhs_inv_impl!(wave_structure(W()), H.rhs_inv_method, y, H, x)
 end
 
 # Error fallback for unsupported combinations
 function _apply_rhs_inv_impl!(trait, method, y, H, x)
-    throw(
+    return throw(
         ArgumentError(
             "Unsupported wave structure/method combination: $(typeof(trait)), $(typeof(method))",
         ),
@@ -960,12 +960,12 @@ end
 # Helper to get 1/RHS for 3D waves
 function _get_rhs_inv(::FullVectorEM, mats, res, ::Type{T}) where {T}
     # FullVectorEM: RHS = μ (same for all 3 components)
-    T.(1.0 ./ mats.μ)
+    return T.(1.0 ./ mats.μ)
 end
 
 function _get_rhs_inv(::FullElastic, mats, res, ::Type{T}) where {T}
     # FullElastic: RHS = ρ (same for all 3 components)
-    T.(1.0 ./ mats.ρ)
+    return T.(1.0 ./ mats.ρ)
 end
 
 # 3D mul! implementation
@@ -985,12 +985,12 @@ end
 function _apply_rhs_inv_3d!(
     y::AbstractVector{T}, H::MatrixFreeEffectiveHamiltonian{Dim3,W,T}, x::AbstractVector{T}
 ) where {W<:WaveType,T}
-    _apply_rhs_inv_3d_impl!(wave_structure(W()), H.rhs_inv_method, y, H, x)
+    return _apply_rhs_inv_3d_impl!(wave_structure(W()), H.rhs_inv_method, y, H, x)
 end
 
 # Error fallback for unsupported combinations (3D)
 function _apply_rhs_inv_3d_impl!(trait, method, y, H, x)
-    throw(
+    return throw(
         ArgumentError(
             "Unsupported wave structure/method combination for 3D: $(typeof(trait)), $(typeof(method))",
         ),
@@ -1134,7 +1134,7 @@ struct RSKGF <: GFMethod
     verbose::Int
 end
 function RSKGF(; atol::Float64=1e-10, rtol::Float64=1e-10, itmax::Int=0, verbose::Int=0)
-    RSKGF(atol, rtol, itmax, verbose)
+    return RSKGF(atol, rtol, itmax, verbose)
 end
 
 """
@@ -1169,7 +1169,7 @@ function MatrixFreeGF(;
     verbose::Int=0,
 )
     method = _convert_rhs_inv_method(rhs_inv_method)
-    MatrixFreeGF{typeof(method)}(method, atol, rtol, itmax, verbose)
+    return MatrixFreeGF{typeof(method)}(method, atol, rtol, itmax, verbose)
 end
 
 # ============================================================================

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -37,11 +37,11 @@ Circle(center::AbstractVector, radius::Real) = Circle(Vec2(center...), Float64(r
 Check if a point is inside the circle.
 """
 function Base.in(point::Vec2, c::Circle)
-    norm(point - c.center) <= c.radius
+    return norm(point - c.center) <= c.radius
 end
 
 function Base.in(point::AbstractVector, c::Circle)
-    Vec2(point...) in c
+    return Vec2(point...) in c
 end
 
 """
@@ -60,7 +60,7 @@ struct Rectangle <: Shape{Dim2}
 end
 
 function Rectangle(center::AbstractVector, size::AbstractVector)
-    Rectangle(Vec2(center...), Vec2(size...))
+    return Rectangle(Vec2(center...), Vec2(size...))
 end
 
 """
@@ -71,11 +71,11 @@ Check if a point is inside the rectangle.
 function Base.in(point::Vec2, r::Rectangle)
     dx = abs(point[1] - r.center[1])
     dy = abs(point[2] - r.center[2])
-    dx <= r.size[1] / 2 && dy <= r.size[2] / 2
+    return dx <= r.size[1] / 2 && dy <= r.size[2] / 2
 end
 
 function Base.in(point::AbstractVector, r::Rectangle)
-    Vec2(point...) in r
+    return Vec2(point...) in r
 end
 
 """
@@ -114,7 +114,7 @@ end
 
 # Constructor with default angle
 function Ellipse(center::AbstractVector, a::Real, b::Real, angle::Real=0.0)
-    Ellipse(Vec2(center...), Float64(a), Float64(b), Float64(angle))
+    return Ellipse(Vec2(center...), Float64(a), Float64(b), Float64(angle))
 end
 
 """
@@ -132,11 +132,11 @@ function Base.in(point::Vec2, e::Ellipse)
     dy_rot = -dx * s + dy * c
 
     # Check if inside ellipse (normalized to unit circle)
-    (dx_rot / e.a)^2 + (dy_rot / e.b)^2 <= 1.0
+    return (dx_rot / e.a)^2 + (dy_rot / e.b)^2 <= 1.0
 end
 
 function Base.in(point::AbstractVector, e::Ellipse)
-    Vec2(point...) in e
+    return Vec2(point...) in e
 end
 
 """
@@ -168,7 +168,7 @@ function Base.in(point::Vec2, poly::Polygon)
         end
         j = i
     end
-    inside
+    return inside
 end
 
 # ============================================================================
@@ -193,11 +193,11 @@ Sphere(center::AbstractVector, radius::Real) = Sphere(Vec3(center...), Float64(r
 Check if a point is inside the sphere.
 """
 function Base.in(point::Vec3, s::Sphere)
-    norm(point - s.center) <= s.radius
+    return norm(point - s.center) <= s.radius
 end
 
 function Base.in(point::AbstractVector, s::Sphere)
-    Vec3(point...) in s
+    return Vec3(point...) in s
 end
 
 """
@@ -214,13 +214,15 @@ struct Cylinder <: Shape{Dim3}
 end
 
 function Cylinder(center::Vec3, radius::Real, height::Real, axis::Vec3=Vec3(0, 0, 1))
-    Cylinder(center, Float64(radius), Float64(height), normalize(axis))
+    return Cylinder(center, Float64(radius), Float64(height), normalize(axis))
 end
 
 function Cylinder(
     center::AbstractVector, radius::Real, height::Real, axis::AbstractVector=Vec3(0, 0, 1)
 )
-    Cylinder(Vec3(center...), Float64(radius), Float64(height), normalize(Vec3(axis...)))
+    return Cylinder(
+        Vec3(center...), Float64(radius), Float64(height), normalize(Vec3(axis...))
+    )
 end
 
 """
@@ -238,7 +240,7 @@ function Base.in(point::Vec3, cyl::Cylinder)
     end
     # Check radial distance
     r_vec = d - z * cyl.axis
-    norm(r_vec) <= cyl.radius
+    return norm(r_vec) <= cyl.radius
 end
 
 """
@@ -259,7 +261,7 @@ end
 
 function Slab(z_min::Real, z_max::Real)
     @assert z_min < z_max "z_min must be less than z_max"
-    Slab(Float64(z_min), Float64(z_max))
+    return Slab(Float64(z_min), Float64(z_max))
 end
 
 """
@@ -268,11 +270,11 @@ end
 Check if a point is inside the slab (z_min ≤ z ≤ z_max).
 """
 function Base.in(point::Vec3, slab::Slab)
-    slab.z_min <= point[3] <= slab.z_max
+    return slab.z_min <= point[3] <= slab.z_max
 end
 
 function Base.in(point::AbstractVector, slab::Slab)
-    Vec3(point...) in slab
+    return Vec3(point...) in slab
 end
 
 # ============================================================================
@@ -295,11 +297,11 @@ end
 Check if a point is inside the segment.
 """
 function Base.in(point::Real, seg::Segment)
-    seg.start <= point <= seg.stop
+    return seg.start <= point <= seg.stop
 end
 
 function Base.in(point::Vec1, seg::Segment)
-    point[1] in seg
+    return point[1] in seg
 end
 
 # ============================================================================
@@ -353,7 +355,7 @@ translate(s::Sphere, offset::Vec3) = Sphere(s.center + offset, s.radius)
 translate(s::Sphere, offset::AbstractVector) = translate(s, Vec3(offset...))
 
 function translate(c::Cylinder, offset::Vec3)
-    Cylinder(c.center + offset, c.radius, c.height, c.axis)
+    return Cylinder(c.center + offset, c.radius, c.height, c.axis)
 end
 translate(c::Cylinder, offset::AbstractVector) = translate(c, Vec3(offset...))
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -76,7 +76,7 @@ function Solver(
 ) where {D<:Dimension,W<:WaveType,N,M<:SolverMethod}
     basis = PlaneWaveBasis(geometry.lattice, cutoff)
     material_arrays = prepare_materials(wave, geometry, resolution, discretization)
-    Solver{D,W,M}(wave, geometry, basis, resolution, material_arrays, method)
+    return Solver{D,W,M}(wave, geometry, basis, resolution, material_arrays, method)
 end
 
 # Convenience constructor for 1D: accept single Int instead of tuple
@@ -88,7 +88,7 @@ function Solver(
     cutoff::Int=7,
     discretization::DiscretizationMethod=SimpleGrid(),
 ) where {W<:WaveType,M<:SolverMethod}
-    Solver(
+    return Solver(
         wave, geometry, (resolution,), method; cutoff=cutoff, discretization=discretization
     )
 end
@@ -124,7 +124,7 @@ X0 = Matrix(X0)
 
 """
 function matrix_dimension(solver::Solver)
-    ncomponents(solver.wave) * solver.basis.num_pw
+    return ncomponents(solver.wave) * solver.basis.num_pw
 end
 
 # ============================================================================
@@ -146,24 +146,24 @@ Select requested bands from computed results.
 =#
 _select_bands(frequencies, eigenvectors, ::Colon) = (frequencies, eigenvectors)
 function _select_bands(frequencies, eigenvectors, bands)
-    (frequencies[bands], eigenvectors[:, bands])
+    return (frequencies[bands], eigenvectors[:, bands])
 end
 
 # Variant that returns first n bands (for KrylovKit where we get all eigenvalues sorted)
 _select_first_bands(frequencies, eigenvectors, ::Colon) = (frequencies, eigenvectors)
 function _select_first_bands(frequencies, eigenvectors, bands)
     nbands = min(length(frequencies), maximum(bands))
-    (frequencies[1:nbands], eigenvectors[:, 1:nbands])
+    return (frequencies[1:nbands], eigenvectors[:, 1:nbands])
 end
 
 # Variant that filters available bands with warning support (for LOBPCG)
 function _select_available_bands(frequencies, eigenvectors, ::Colon, _)
-    (frequencies, eigenvectors, false)
+    return (frequencies, eigenvectors, false)
 end
 function _select_available_bands(frequencies, eigenvectors, bands, nev_available)
     actual_bands = filter(b -> b <= nev_available, bands)
     warn_missing = length(actual_bands) < length(bands)
-    (frequencies[actual_bands], eigenvectors[:, actual_bands], warn_missing)
+    return (frequencies[actual_bands], eigenvectors[:, actual_bands], warn_missing)
 end
 
 # ============================================================================
@@ -188,7 +188,7 @@ function prepare_materials(
     resolution,
     method::DiscretizationMethod=SimpleGrid(),
 )
-    throw(
+    return throw(
         ArgumentError(
             "Unsupported wave type / dimension combination: $(typeof(wave)) with $(typeof(geometry).parameters[1])",
         ),
@@ -205,7 +205,7 @@ function prepare_materials(
     μ = discretize(geometry, resolution, :μ, method)
     # For TE: use properly averaged ε⁻¹ (important for SubpixelAverage)
     ε_inv = discretize(geometry, resolution, :ε_inv, method)
-    (ε=ε, μ=μ, ε_inv=ε_inv)
+    return (ε=ε, μ=μ, ε_inv=ε_inv)
 end
 
 function prepare_materials(
@@ -218,7 +218,7 @@ function prepare_materials(
     μ = discretize(geometry, resolution, :μ, method)
     # For TM: use properly averaged μ⁻¹
     μ_inv = discretize(geometry, resolution, :μ_inv, method)
-    (ε=ε, μ=μ, μ_inv=μ_inv)
+    return (ε=ε, μ=μ, μ_inv=μ_inv)
 end
 
 function prepare_materials(
@@ -229,7 +229,7 @@ function prepare_materials(
 )
     ρ = discretize(geometry, resolution, :ρ, method)
     C44 = discretize(geometry, resolution, :C44, method)
-    (ρ=ρ, C44=C44)
+    return (ρ=ρ, C44=C44)
 end
 
 function prepare_materials(
@@ -242,7 +242,7 @@ function prepare_materials(
     C11 = discretize(geometry, resolution, :C11, method)
     C12 = discretize(geometry, resolution, :C12, method)
     C44 = discretize(geometry, resolution, :C44, method)
-    (ρ=ρ, C11=C11, C12=C12, C44=C44)
+    return (ρ=ρ, C11=C11, C12=C12, C44=C44)
 end
 
 # 1D Photonic
@@ -255,7 +255,7 @@ function prepare_materials(
     ε = discretize(geometry, resolution, :ε, method)
     μ = discretize(geometry, resolution, :μ, method)
     ε_inv = discretize(geometry, resolution, :ε_inv, method)
-    (ε=ε, μ=μ, ε_inv=ε_inv)
+    return (ε=ε, μ=μ, ε_inv=ε_inv)
 end
 
 # 1D Longitudinal elastic
@@ -267,7 +267,7 @@ function prepare_materials(
 )
     ρ = discretize(geometry, resolution, :ρ, method)
     C11 = discretize(geometry, resolution, :C11, method)
-    (ρ=ρ, C11=C11)
+    return (ρ=ρ, C11=C11)
 end
 
 # 3D Full Vector EM (H-field formulation)
@@ -280,7 +280,7 @@ function prepare_materials(
 )
     ε_inv = discretize(geometry, resolution, :ε_inv, method)
     μ = discretize(geometry, resolution, :μ, method)
-    (ε_inv=ε_inv, μ=μ)
+    return (ε_inv=ε_inv, μ=μ)
 end
 
 # 3D Transverse EM (H-field formulation with transverse projection)
@@ -293,7 +293,7 @@ function prepare_materials(
 )
     ε_inv = discretize(geometry, resolution, :ε_inv, method)
     μ = discretize(geometry, resolution, :μ, method)
-    (ε_inv=ε_inv, μ=μ)
+    return (ε_inv=ε_inv, μ=μ)
 end
 
 # 3D Full Elastic
@@ -308,7 +308,7 @@ function prepare_materials(
     C11 = discretize(geometry, resolution, :C11, method)
     C12 = discretize(geometry, resolution, :C12, method)
     C44 = discretize(geometry, resolution, :C44, method)
-    (ρ=ρ, C11=C11, C12=C12, C44=C44)
+    return (ρ=ρ, C11=C11, C12=C12, C44=C44)
 end
 
 # ============================================================================
@@ -559,10 +559,10 @@ end
 
 # 1D convenience methods accepting Vector{Float64} (for compatibility with solve interface)
 function build_matrices(solver::Solver{Dim1,Photonic1D}, k::Vector{Float64})
-    build_matrices(solver, k[1])
+    return build_matrices(solver, k[1])
 end
 function build_matrices(solver::Solver{Dim1,Longitudinal1D}, k::Vector{Float64})
-    build_matrices(solver, k[1])
+    return build_matrices(solver, k[1])
 end
 
 # ============================================================================
@@ -575,7 +575,7 @@ end
 Create 3x3 skew-symmetric matrix for cross product: [k]× such that [k]× v = k × v
 """
 function skew_matrix(k::AbstractVector)
-    [
+    return [
         0.0 -k[3] k[2];
         k[3] 0.0 -k[1];
         -k[2] k[1] 0.0
@@ -770,7 +770,7 @@ function block_diagonal_weight(M::AbstractMatrix, n::Int)
     Z = zeros(eltype(M), N, N)
     n == 2 && return [M Z; Z M]
     n == 3 && return [M Z Z; Z M Z; Z Z M]
-    error("Unsupported block size: $n")
+    return error("Unsupported block size: $n")
 end
 
 function get_weight_matrix(solver::Solver{Dim2,TEWave})
@@ -832,7 +832,7 @@ LHS, RHS = build_matrices(solver, k)
 - [`solve_at_k_with_vectors`](@ref): Returns eigenvectors in the 2N transverse basis
 """
 function get_weight_matrix(solver::Solver{Dim3,TransverseEM})
-    error(
+    return error(
         "get_weight_matrix for TransverseEM is k-dependent. " *
         "Use the RHS matrix from build_matrices(solver, k) instead.",
     )
@@ -863,26 +863,26 @@ Solve the eigenvalue problem at wave vector k.
 - `modes`: Corresponding eigenvectors
 """
 function solve(solver::Solver, k; bands=1:10)
-    solve_impl(solver, k, solver.method; bands=bands)
+    return solve_impl(solver, k, solver.method; bands=bands)
 end
 
 # Convenience method with SVector
 function solve(solver::Solver{Dim2}, k::SVector{2}; bands=1:10)
-    solve(solver, Vector(k); bands=bands)
+    return solve(solver, Vector(k); bands=bands)
 end
 
 # Convenience method with tuple
 function solve(solver::Solver{Dim2}, k::Tuple{Real,Real}; bands=1:10)
-    solve(solver, [Float64(k[1]), Float64(k[2])]; bands=bands)
+    return solve(solver, [Float64(k[1]), Float64(k[2])]; bands=bands)
 end
 
 # Convenience methods for 3D
 function solve(solver::Solver{Dim3}, k::SVector{3}; bands=1:10)
-    solve(solver, Vector(k); bands=bands)
+    return solve(solver, Vector(k); bands=bands)
 end
 
 function solve(solver::Solver{Dim3}, k::Tuple{Real,Real,Real}; bands=1:10)
-    solve(solver, [Float64(k[1]), Float64(k[2]), Float64(k[3])]; bands=bands)
+    return solve(solver, [Float64(k[1]), Float64(k[2]), Float64(k[3])]; bands=bands)
 end
 
 # ============================================================================
@@ -985,27 +985,27 @@ function _solve_at_k_impl(
 )
     # Dense method ignores X0 and P
     LHS, RHS = build_matrices(solver, k)
-    _solve_dense(LHS, RHS, bands, method.shift)
+    return _solve_dense(LHS, RHS, bands, method.shift)
 end
 
 function _solve_at_k_impl(
     solver::Solver, k, method::KrylovKitMethod; bands=1:10, X0=nothing, P=nothing
 )
     # KrylovKit currently ignores X0 and P
-    _solve_krylovkit(solver, k, method, bands)
+    return _solve_krylovkit(solver, k, method, bands)
 end
 
 function _solve_at_k_impl(
     solver::Solver, k, method::LOBPCGMethod; bands=1:10, X0=nothing, P=nothing
 )
-    _solve_lobpcg_at_k(solver, k, method; bands=bands, X0=X0, P=P)
+    return _solve_lobpcg_at_k(solver, k, method; bands=bands, X0=X0, P=P)
 end
 
 # Fallback
 function _solve_at_k_impl(
     solver::Solver, k, method::SolverMethod; bands=1:10, X0=nothing, P=nothing
 )
-    error("solve_at_k not implemented for method: $(typeof(method))")
+    return error("solve_at_k not implemented for method: $(typeof(method))")
 end
 
 # ============================================================================
@@ -1016,7 +1016,7 @@ function solve_impl(
     solver::Solver{Dim2}, k::Vector{<:Real}, method::DenseMethod; bands=1:10
 )
     LHS, RHS = build_matrices(solver, k)
-    _solve_dense(LHS, RHS, bands, method.shift)
+    return _solve_dense(LHS, RHS, bands, method.shift)
 end
 
 # ============================================================================
@@ -1027,7 +1027,7 @@ function solve_impl(
     solver::Solver{Dim3}, k::Vector{<:Real}, method::DenseMethod; bands=1:10
 )
     LHS, RHS = build_matrices(solver, k)
-    _solve_dense(LHS, RHS, bands, method.shift)
+    return _solve_dense(LHS, RHS, bands, method.shift)
 end
 
 # ============================================================================
@@ -1036,7 +1036,7 @@ end
 
 function solve_impl(solver::Solver{Dim1}, k::Real, method::DenseMethod; bands=1:10)
     LHS, RHS = build_matrices(solver, k)
-    _solve_dense(LHS, RHS, bands, method.shift)
+    return _solve_dense(LHS, RHS, bands, method.shift)
 end
 
 # ============================================================================
@@ -1099,7 +1099,7 @@ end
 function solve_impl(
     solver::Solver{Dim2,W}, k::Vector{<:Real}, method::KrylovKitMethod; bands=1:10
 ) where {W<:WaveType}
-    _solve_krylovkit(solver, k, method, bands)
+    return _solve_krylovkit(solver, k, method, bands)
 end
 
 # ============================================================================
@@ -1109,7 +1109,7 @@ end
 function solve_impl(
     solver::Solver{Dim1,W}, k::Real, method::KrylovKitMethod; bands=1:10
 ) where {W<:WaveType}
-    _solve_krylovkit(solver, [Float64(k)], method, bands)
+    return _solve_krylovkit(solver, [Float64(k)], method, bands)
 end
 
 # ============================================================================
@@ -1119,7 +1119,7 @@ end
 function solve_impl(
     solver::Solver{Dim3,W}, k::Vector{<:Real}, method::KrylovKitMethod; bands=1:10
 ) where {W<:WaveType}
-    _solve_krylovkit(solver, Vector{Float64}(k), method, bands)
+    return _solve_krylovkit(solver, Vector{Float64}(k), method, bands)
 end
 
 # ============================================================================
@@ -1250,7 +1250,7 @@ For photonic: ω² ~ (c/a)² ~ 1 (already normalized)
 For phononic: ω² ~ (c_s * k)² where c_s is shear wave speed
 =#
 function _estimate_eigenvalue_scale(solver::Solver{D,W}, k::Vector{Float64}) where {D,W}
-    _estimate_eigenvalue_scale(solver.wave, solver, k)
+    return _estimate_eigenvalue_scale(solver.wave, solver, k)
 end
 
 # Photonic: eigenvalues are already O(1) due to normalization
@@ -1258,7 +1258,7 @@ _estimate_eigenvalue_scale(::PhotonicWave, solver, k) = 1.0
 
 # Phononic: estimate from material properties and k (dispatch on material type)
 function _estimate_eigenvalue_scale(::PhononicWave, solver, k)
-    _eigenvalue_scale_from_material(solver.geometry.background, k)
+    return _eigenvalue_scale_from_material(solver.geometry.background, k)
 end
 
 # Multiple dispatch for material types
@@ -1267,7 +1267,7 @@ function _eigenvalue_scale_from_material(mat::IsotropicElastic, k)
     c² = mat.C11 / mat.ρ
     k_mag = norm(k)
     # Eigenvalue scale: ω² ~ c² * k²
-    max(c² * k_mag^2, 1.0)  # Ensure at least 1
+    return max(c² * k_mag^2, 1.0)  # Ensure at least 1
 end
 
 # Fallback for other material types
@@ -1316,7 +1316,7 @@ function _solve_krylovkit_shifted(
 
     # Define operator: (A - σB)⁻¹ B x
     function shifted_op(x)
-        shifted_fact \ (RHS * x)
+        return shifted_fact \ (RHS * x)
     end
 
     # Initial vector
@@ -1789,19 +1789,19 @@ end
 
 # Dispatch for each dimension
 function solve_impl(solver::Solver{Dim1}, k::Real, method::LOBPCGMethod; bands=1:10)
-    _solve_lobpcg(solver, k, method; bands=bands)
+    return _solve_lobpcg(solver, k, method; bands=bands)
 end
 
 function solve_impl(
     solver::Solver{Dim2}, k::Vector{<:Real}, method::LOBPCGMethod; bands=1:10
 )
-    _solve_lobpcg(solver, k, method; bands=bands)
+    return _solve_lobpcg(solver, k, method; bands=bands)
 end
 
 function solve_impl(
     solver::Solver{Dim3}, k::Vector{<:Real}, method::LOBPCGMethod; bands=1:10
 )
-    _solve_lobpcg(solver, k, method; bands=bands)
+    return _solve_lobpcg(solver, k, method; bands=bands)
 end
 
 # ============================================================================
@@ -1809,7 +1809,7 @@ end
 # ============================================================================
 
 function solve_impl(solver::Solver, k, ::BasicRSCG; bands=1:10)
-    error(
+    return error(
         "BasicRSCG is designed for Green's function / DOS / LDOS calculations, " *
         "not for eigenvalue problems. Use DenseMethod() for band structure, " *
         "or use compute_dos() / compute_ldos() with BasicRSCG solver.",
@@ -1821,7 +1821,7 @@ end
 # ============================================================================
 
 function solve_impl(solver::Solver, k, method::SolverMethod; bands=1:10)
-    error(
+    return error(
         "Unsupported solver method: $(typeof(method)). " *
         "Supported methods: DenseMethod(), KrylovKitMethod(), LOBPCGMethod().",
     )
@@ -1848,7 +1848,7 @@ Compute group velocity v_g = ∂ω/∂k at wave vector k.
   - 1D: Vector of Float64
 """
 function group_velocity(solver::Solver, k; bands=1:10, δk=1e-5)
-    group_velocity_impl(solver, k, solver.method; bands=bands, δk=δk)
+    return group_velocity_impl(solver, k, solver.method; bands=bands, δk=δk)
 end
 
 # ============================================================================
@@ -1882,13 +1882,15 @@ end
 function group_velocity_impl(
     solver::Solver{Dim2}, k::SVector{2}, method::DenseMethod; bands=1:10, δk=1e-5
 )
-    group_velocity_impl(solver, Vector(k), method; bands=bands, δk=δk)
+    return group_velocity_impl(solver, Vector(k), method; bands=bands, δk=δk)
 end
 
 function group_velocity_impl(
     solver::Solver{Dim2}, k::Tuple{Real,Real}, method::DenseMethod; bands=1:10, δk=1e-5
 )
-    group_velocity_impl(solver, [Float64(k[1]), Float64(k[2])], method; bands=bands, δk=δk)
+    return group_velocity_impl(
+        solver, [Float64(k[1]), Float64(k[2])], method; bands=bands, δk=δk
+    )
 end
 
 # ============================================================================
@@ -1909,7 +1911,7 @@ end
 # ============================================================================
 
 function group_velocity_impl(solver::Solver, k, ::BasicRSCG; bands=1:10, δk=1e-5)
-    error("group_velocity with BasicRSCG is not yet implemented. Use DenseMethod().")
+    return error("group_velocity with BasicRSCG is not yet implemented. Use DenseMethod().")
 end
 
 # ============================================================================
@@ -1917,7 +1919,7 @@ end
 # ============================================================================
 
 function group_velocity_impl(solver::Solver, k, method::Any; bands=1:10, δk=1e-5)
-    error("Unsupported solver method for group_velocity: $(typeof(method)).")
+    return error("Unsupported solver method for group_velocity: $(typeof(method)).")
 end
 
 # ============================================================================
@@ -1932,7 +1934,7 @@ Construct a solver for photonic/phononic crystal eigenvalue problems.
 See concrete method signatures for detailed documentation and keyword arguments.
 """
 function Solver(wave::Any, geometry::Any, resolution::Any; kwargs...)
-    error(
+    return error(
         "Solver: expected (wave::WaveType, geometry::Geometry, resolution::Tuple{Int,...}), " *
         "got ($(typeof(wave)), $(typeof(geometry)), $(typeof(resolution)))",
     )
@@ -1946,7 +1948,7 @@ Solve eigenvalue problem at a single k-point.
 See concrete method signatures for detailed documentation and keyword arguments.
 """
 function solve_at_k(solver::Any, k::Any, method::Any; kwargs...)
-    error(
+    return error(
         "solve_at_k: expected (solver::Solver, k, method::SolverMethod), " *
         "got ($(typeof(solver)), $(typeof(k)), $(typeof(method)))",
     )
@@ -1960,7 +1962,7 @@ Return the matrix dimension for the eigenvalue problem.
 See concrete method signatures for detailed documentation.
 """
 function matrix_dimension(solver::Any)
-    error("matrix_dimension: expected solver::Solver, got $(typeof(solver))")
+    return error("matrix_dimension: expected solver::Solver, got $(typeof(solver))")
 end
 
 """
@@ -1971,7 +1973,7 @@ Solve eigenvalue problem and return both frequencies and eigenvectors.
 See concrete method signatures for detailed documentation and keyword arguments.
 """
 function solve_at_k_with_vectors(solver::Any, k::Any, method::Any; kwargs...)
-    error(
+    return error(
         "solve_at_k_with_vectors: expected (solver::AbstractSolver, k, method::SolverMethod), " *
         "got ($(typeof(solver)), $(typeof(k)), $(typeof(method)))",
     )
@@ -1985,7 +1987,7 @@ Build the LHS and RHS matrices for the generalized eigenvalue problem.
 See concrete method signatures for detailed documentation.
 """
 function build_matrices(solver::Any, k::Any)
-    error(
+    return error(
         "build_matrices: expected (solver::AbstractSolver, k), " *
         "got ($(typeof(solver)), $(typeof(k)))",
     )
@@ -2003,5 +2005,7 @@ the inner product in the function space.
 See concrete method signatures for detailed documentation.
 """
 function get_weight_matrix(solver::Any)
-    error("get_weight_matrix: expected solver::AbstractSolver, got $(typeof(solver))")
+    return error(
+        "get_weight_matrix: expected solver::AbstractSolver, got $(typeof(solver))"
+    )
 end

--- a/src/supercell.jl
+++ b/src/supercell.jl
@@ -16,19 +16,19 @@ Create a supercell lattice by scaling the original lattice vectors.
 function _supercell_lattice(lat::Lattice{Dim1}, size::Tuple{Int})
     Nx = size[1]
     a1 = lat.vectors[1][1]  # Extract scalar from Vec1
-    Lattice(Nx * a1)  # Lattice(::Real) constructor for 1D
+    return Lattice(Nx * a1)  # Lattice(::Real) constructor for 1D
 end
 
 function _supercell_lattice(lat::Lattice{Dim2}, size::NTuple{2,Int})
     Nx, Ny = size
     a1, a2 = lat.vectors
-    Lattice(Nx * a1, Ny * a2)
+    return Lattice(Nx * a1, Ny * a2)
 end
 
 function _supercell_lattice(lat::Lattice{Dim3}, size::NTuple{3,Int})
     Nx, Ny, Nz = size
     a1, a2, a3 = lat.vectors
-    Lattice(Nx * a1, Ny * a2, Nz * a3)
+    return Lattice(Nx * a1, Ny * a2, Nz * a3)
 end
 
 #=
@@ -151,7 +151,7 @@ function create_supercell(
     new_inclusions = _replicate_inclusions(
         geo.inclusions, geo.lattice, size; skip_positions=point_defects
     )
-    Geometry(new_lat, geo.background, new_inclusions)
+    return Geometry(new_lat, geo.background, new_inclusions)
 end
 
 function create_supercell(
@@ -163,7 +163,7 @@ function create_supercell(
     new_inclusions = _replicate_inclusions(
         geo.inclusions, geo.lattice, size; skip_positions=point_defects
     )
-    Geometry(new_lat, geo.background, new_inclusions)
+    return Geometry(new_lat, geo.background, new_inclusions)
 end
 
 function create_supercell(
@@ -175,12 +175,12 @@ function create_supercell(
     new_inclusions = _replicate_inclusions(
         geo.inclusions, geo.lattice, size; skip_positions=point_defects
     )
-    Geometry(new_lat, geo.background, new_inclusions)
+    return Geometry(new_lat, geo.background, new_inclusions)
 end
 
 # Convenience: allow integer for 1D
 function create_supercell(geo::Geometry{Dim1}, n::Int; kwargs...)
-    create_supercell(geo, (n,); kwargs...)
+    return create_supercell(geo, (n,); kwargs...)
 end
 
 # ============================================================================
@@ -273,7 +273,7 @@ end
 # Error fallback for invalid create_supercell arguments
 function create_supercell(args...)
     arg_types = isempty(args) ? "()" : "(" * join(typeof.(args), ", ") * ")"
-    error(
+    return error(
         "No matching create_supercell method for arguments: $arg_types. " *
         "Use create_supercell(geo::Geometry, size::NTuple{D,Int}; point_defects=[]).",
     )

--- a/src/tmm/layers.jl
+++ b/src/tmm/layers.jl
@@ -72,7 +72,7 @@ function Multilayer(layers::Vector{<:Layer}, incident::Material, substrate::Mate
     # Convert layers
     converted_layers = [Layer(convert(M, material(l)), thickness(l)) for l in layers]
 
-    Multilayer{M}(converted_layers, convert(M, incident), convert(M, substrate))
+    return Multilayer{M}(converted_layers, convert(M, incident), convert(M, substrate))
 end
 
 """
@@ -150,7 +150,7 @@ function periodic_multilayer(
         substrate = incident
     end
 
-    Multilayer(repeated_layers, incident, substrate)
+    return Multilayer(repeated_layers, incident, substrate)
 end
 
 """
@@ -188,5 +188,5 @@ function bragg_mirror(
     # Unit cell: high-index then low-index
     unit_cell = [Layer(mat_hi, d_hi), Layer(mat_lo, d_lo)]
 
-    periodic_multilayer(unit_cell, N; incident=incident, substrate=substrate)
+    return periodic_multilayer(unit_cell, N; incident=incident, substrate=substrate)
 end

--- a/src/tmm/matrices.jl
+++ b/src/tmm/matrices.jl
@@ -120,12 +120,12 @@ end
 # Helper function to get refractive index from material
 function _get_n(mat::Dielectric)
     # n = √ε for non-magnetic materials
-    sqrt(mat.ε)
+    return sqrt(mat.ε)
 end
 
 function _get_n(mat::LossyDielectric)
     # n = √(εμ) for complex materials
-    sqrt(mat.ε * mat.μ)
+    return sqrt(mat.ε * mat.μ)
 end
 
 # ============================================================================

--- a/src/waves.jl
+++ b/src/waves.jl
@@ -300,7 +300,7 @@ Enables dispatch based on dimensionality and number of components.
 """
 # Error fallback for unsupported wave types
 function wave_structure(w::WaveType)
-    throw(ArgumentError("Unsupported wave type for wave_structure: $(typeof(w))"))
+    return throw(ArgumentError("Unsupported wave type for wave_structure: $(typeof(w))"))
 end
 
 wave_structure(::TEWave) = ScalarWave2D()
@@ -324,7 +324,7 @@ Return the number of field components for a wave type.
 """
 # Error fallback for unsupported wave types
 function ncomponents(w::WaveType)
-    throw(ArgumentError("Unsupported wave type for ncomponents: $(typeof(w))"))
+    return throw(ArgumentError("Unsupported wave type for ncomponents: $(typeof(w))"))
 end
 
 ncomponents(::TEWave) = 1
@@ -344,7 +344,7 @@ Return the applicable dimension type for a wave type.
 """
 # Error fallback for unsupported wave types
 function applicable_dimension(::Type{W}) where {W<:WaveType}
-    throw(ArgumentError("Unsupported wave type for applicable_dimension: $W"))
+    return throw(ArgumentError("Unsupported wave type for applicable_dimension: $W"))
 end
 
 applicable_dimension(::Type{TEWave}) = Dim2


### PR DESCRIPTION
## Test plan
- Ran `format(".")` with JuliaFormatter v2.10.1 locally; reformats 27 files (+232 / -220).
- Changes are pure formatting: the v2 rule that inserts explicit `return` on trailing expressions, plus multiline-string reindentation. No behavior change.
- Confirms the `format` CI job goes green.