### PR TITLE
fix: report the dimension limit of DOS and LDOS instead of a missing package

### DIFF
--- a/src/rscg.jl
+++ b/src/rscg.jl
@@ -1317,6 +1317,17 @@ function compute_dos(
     η::Real=1e-3,
     n_random::Int=10,
 )
+    if !(solver isa Solver{Dim2})
+        throw(
+            ArgumentError(
+                "compute_dos with an explicit GFMethod is implemented for 2D solvers only. " *
+                "In 1D, use compute_dos(solver, ω_values, k_points). " *
+                "There is no 3D method; Green's functions, by contrast, are " *
+                "dimension-generic (see compute_greens_function).",
+            ),
+        )
+    end
+
     method_name = typeof(method).name.name
     if method_name in (:RSKGF, :MatrixFreeGF)
         throw(
@@ -1406,6 +1417,26 @@ function compute_ldos(
     method::GFMethod;
     η::Real=1e-3,
 )
+    if solver isa Solver{Dim3}
+        if !(method isa MatrixFreeGF)
+            throw(
+                ArgumentError(
+                    "compute_ldos in 3D is implemented for MatrixFreeGF() only; " *
+                    "got $(typeof(method)).",
+                ),
+            )
+        end
+        # MatrixFreeGF in 3D exists in the extension. Reaching here means the
+        # extension is not loaded, so the branch below is the correct message.
+    elseif !(solver isa Solver{Dim2})
+        throw(
+            ArgumentError(
+                "compute_ldos with an explicit GFMethod is implemented for 2D solvers only. " *
+                "In 1D, use compute_ldos(solver, position, ω_values, k_points).",
+            ),
+        )
+    end
+
     method_name = typeof(method).name.name
     if method_name in (:RSKGF, :MatrixFreeGF)
         throw(

--- a/test/dimension_guards_test.jl
+++ b/test/dimension_guards_test.jl
@@ -83,4 +83,22 @@ using PhoXonic
         @test_throws MethodError compute_dos_stochastic(s3, ω_values, k_points)
         @test_throws MethodError compute_ldos(s3, [0.5, 0.5, 0.5], ω_values, k_points)
     end
+
+    @testset "an unsupported dimension is reported as such" begin
+        s3 = Solver(TransverseEM(), geo3, (8, 8, 8), DenseMethod(); cutoff=2)
+        ω_values = [0.5, 1.0, 1.5]
+        k_points = [[0.1, 0.1, 0.1]]
+
+        # The failure must name the dimension, not blame the algorithm.
+        @test_throws ArgumentError compute_dos(s3, ω_values, k_points, DirectGF())
+        @test_throws "2D solvers only" compute_dos(s3, ω_values, k_points, DirectGF())
+        @test_throws "2D solvers only" compute_dos(s3, ω_values, k_points, RSKGF())
+        @test_throws "MatrixFreeGF() only" compute_ldos(
+            s3, [0.5, 0.5, 0.5], ω_values, k_points, DirectGF()
+        )
+
+        # 1D DOS exists, but only without an explicit GFMethod.
+        s1 = Solver(Photonic1D(), geo1, (64,); cutoff=5)
+        @test_throws "2D solvers only" compute_dos(s1, ω_values, [0.1, 0.2], DirectGF())
+    end
 end

--- a/test/rsk_ext/runtests.jl
+++ b/test/rsk_ext/runtests.jl
@@ -115,4 +115,49 @@ using ReducedShiftedKrylov  # This triggers the extension loading
 
         @test length(dos_rsk) == length(ω_values)
     end
+
+    @testset "3D: no DOS anywhere, LDOS only for MatrixFreeGF" begin
+        lat3 = cubic_lattice(1.0)
+        geo3 = Geometry(
+            lat3, Dielectric(1.0), [(Sphere([0.5, 0.5, 0.5], 0.2), Dielectric(9.0))]
+        )
+        ω_values = [0.5, 1.0, 1.5]
+        k_points = [[0.1, 0.1, 0.1]]
+        pos = [0.5, 0.5, 0.5]
+
+        s_fv = Solver(FullVectorEM(), geo3, (8, 8, 8), DenseMethod(); cutoff=2)
+        s_te = Solver(TransverseEM(), geo3, (8, 8, 8), DenseMethod(); cutoff=2)
+
+        function failure_message(f)
+            try
+                f()
+            catch e
+                return sprint(showerror, e)
+            end
+            return ""
+        end
+
+        # ReducedShiftedKrylov is loaded in this file, so the error must not ask
+        # the user to load it.
+        for method in (DirectGF(), RSKGF(), MatrixFreeGF())
+            msg = failure_message(() -> compute_dos(s_fv, ω_values, k_points, method))
+            @test occursin("2D solvers only", msg)
+            @test !occursin("requires ReducedShiftedKrylov", msg)
+        end
+
+        msg = failure_message(() -> compute_ldos(s_fv, pos, ω_values, k_points, RSKGF()))
+        @test occursin("MatrixFreeGF() only", msg)
+        @test !occursin("requires ReducedShiftedKrylov", msg)
+
+        # 3D LDOS does exist, with MatrixFreeGF. This is the proof asymmetry.
+        ldos = compute_ldos(s_fv, pos, ω_values, k_points, MatrixFreeGF())
+        @test length(ldos) == length(ω_values)
+        @test all(isfinite, ldos)
+
+        # ... but not for every 3D wave type: TransverseEM has no right-hand-side
+        # inverse, so it reaches the extension method and fails there (#72).
+        @test_throws "TransverseEM" compute_ldos(
+            s_te, pos, ω_values, k_points, MatrixFreeGF()
+        )
+    end
 end


### PR DESCRIPTION
Closes #70.

A dimension check ahead of the generic `GFMethod` handlers in `src/rscg.jl`
(`:1312`, `:1401`), plus the tests that pin the new wording. The commit message
explains why the two functions cannot share the check.

## Evidence

The tests were written first and observed failing on `main`:

```
Expected: "2D solvers only"
 Message: "ArgumentError: Unsupported GFMethod: DirectGF.
           Available methods: DirectGF(), RSKGF(), MatrixFreeGF()"
```

`test/dimension_guards_test.jl` went 26/4 → 30/0, the `ext` group 43/7 → 50/0.
The extension test is the only place the false message was observable, since it
is the only place the extension is loaded.

Two assertions in that file passed before this change and are pinned on purpose:
3D LDOS does exist for `FullVectorEM` with `MatrixFreeGF()`, and `TransverseEM`
has no right-hand-side inverse so 3D LDOS is unavailable for it (#72).

## Verification

- `Pkg.test()`, both groups: core 1650/1650, ext 50/50.
- Regressions run rather than reasoned about: the existing `"GFMethod fallback"`
  testset, the 2D `DirectGF` paths, and the correct "requires ReducedShiftedKrylov"
  advice for 2D `RSKGF()` / `MatrixFreeGF()` without the extension.
- JuliaFormatter v2 (Blue) reports no change. `Project.toml` version unchanged at 0.3.0.
