### PR TITLE
docs: correct the dimension-support table and document the (D,W) lattice

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -33,6 +33,7 @@ makedocs(;
             "Plotting" => "api-plotting.md",
             "I/O" => "api-io.md",
         ],
+        "Architecture" => "architecture.md",
         "Dependencies" => "dependencies.md",
     ],
     # Source links always point to public repo

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,0 +1,98 @@
+# Architecture
+
+This page describes how the solver types fit together in v0.3.0, and which
+analysis functions exist in which dimension. It documents what is in `main`;
+the last section says what is not.
+
+## The (dimension, wave type) lattice
+
+A wave type belongs to exactly one dimension. Dimension and wave type are not
+independent axes, so the valid solvers are not the free product of the two.
+There are nine:
+
+| Dimension | Photonic | Phononic |
+|-----------|----------|----------|
+| 1D | [`Photonic1D`](api-solver.md#PhoXonic.Photonic1D) | [`Longitudinal1D`](api-solver.md#PhoXonic.Longitudinal1D) |
+| 2D | [`TEWave`](api-solver.md#PhoXonic.TEWave), [`TMWave`](api-solver.md#PhoXonic.TMWave) | [`SHWave`](api-solver.md#PhoXonic.SHWave), [`PSVWave`](api-solver.md#PhoXonic.PSVWave) |
+| 3D | [`TransverseEM`](api-solver.md#PhoXonic.TransverseEM), [`FullVectorEM`](api-solver.md#PhoXonic.FullVectorEM) | [`FullElastic`](api-solver.md#PhoXonic.FullElastic) |
+
+A combination outside this table is rejected when the solver is constructed, not
+later when the operator is assembled:
+
+```julia
+julia> lat = lattice_1d(1.0);
+julia> geo = Geometry(lat, Dielectric(1.0), [(Segment(0.2, 0.8), Dielectric(9.0))]);
+julia> Solver(TEWave(), geo, (64,); cutoff=5)
+ERROR: ArgumentError: Unsupported wave type / dimension combination: TEWave with Dim1
+```
+
+[`TEWave`](api-solver.md#PhoXonic.TEWave) is a two-dimensional polarization, so
+there is nothing for it to solve on a one-dimensional lattice. The same holds for
+every combination absent from the table.
+
+## Dimension support of the analysis functions
+
+Band structures are available in every dimension. The post-analysis functions are
+not, because the quantities they compute do not all exist in every dimension, and
+because some of them are not implemented yet.
+
+| Function | 1D | 2D | 3D |
+|----------|:--:|:--:|----|
+| [`solve`](api-solver.md#PhoXonic.solve), [`compute_bands`](api-solver.md#PhoXonic.compute_bands) | ✓ | ✓ | ✓ |
+| [`compute_greens_function`](api-advanced.md#PhoXonic.compute_greens_function) | ✓ | ✓ | ✓ |
+| [`compute_dos`](api-advanced.md#PhoXonic.compute_dos) | ✓ | ✓ | — |
+| [`compute_ldos`](api-advanced.md#PhoXonic.compute_ldos) | ✓ | ✓ | [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF) only |
+| [`compute_zak_phase`](api-advanced.md#PhoXonic.compute_zak_phase) | ✓ | — | — |
+| [`compute_wilson_spectrum`](api-advanced.md#PhoXonic.compute_wilson_spectrum) | — | ✓ | — |
+
+A dash means the quantity is unavailable, but for two different reasons. The Zak
+phase is a one-dimensional invariant and the Wilson loop spectrum a
+two-dimensional one, so outside their dimension there is nothing to compute;
+calling them there is a `MethodError`, never a wrong number. A three-dimensional
+[`compute_dos`](api-advanced.md#PhoXonic.compute_dos), by contrast, would be
+meaningful and is simply not implemented.
+
+The one conditional cell is
+[`compute_ldos`](api-advanced.md#PhoXonic.compute_ldos) in 3D: it needs
+[`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF), from the
+`ReducedShiftedKrylov` extension, and a wave type whose right-hand side can be
+inverted ([`FullVectorEM`](api-solver.md#PhoXonic.FullVectorEM) or
+[`FullElastic`](api-solver.md#PhoXonic.FullElastic), not
+[`TransverseEM`](api-solver.md#PhoXonic.TransverseEM)). See
+[DOS / LDOS](greens_function.md#Dimension-Support) for which `GFMethod` each
+function accepts in each dimension.
+
+## Two stages
+
+Every calculation in PhoXonic.jl passes through the same two stages.
+
+**Stage 1, dispersion.** A [`Solver`](api-solver.md#PhoXonic.Solver) assembles the
+eigenvalue problem for a wave type on a geometry, and
+[`solve`](api-solver.md#PhoXonic.solve) or
+[`compute_bands`](api-solver.md#PhoXonic.compute_bands) returns the frequencies
+ω_n(k) and the modes.
+
+**Stage 2, post-analysis.** Everything else consumes the output of stage 1, or
+the operator behind it: the density of states, the local density of states,
+Green's functions, the Zak phase, the Wilson loop spectrum, field reconstruction.
+
+The two stages are why the dimension support above is uneven. Stage 1 works
+wherever a `(dimension, wave type)` pair exists, that is, everywhere. Stage 2
+depends on the quantity: some do not exist in a given dimension, and some are
+simply not implemented there.
+
+## Not in v0.3.0
+
+Three things a reader may expect to find here, and where they actually stand as
+of v0.3.0.
+
+**A unified `solve(problem, algorithm)` entry point.** The SciML idiom of
+describing a problem and then choosing an algorithm to solve it is a design, not
+code in `main`. The exported [`solve`](api-solver.md#PhoXonic.solve) is the
+eigenvalue problem at one wave vector, and is unrelated to it. Stage 2 is reached
+through the individual `compute_*` functions.
+
+**Berry curvature and valley analysis.** Designed, not in `main`.
+
+**A three-dimensional density of states.** Not implemented. Green's functions in
+3D are available; the density of states built on them is not.

--- a/docs/src/greens_function.md
+++ b/docs/src/greens_function.md
@@ -28,8 +28,11 @@ G = compute_greens_function(solver, k, ω_values, source, MatrixFreeGF(); η=0.0
 | Method | Memory | Best For | Requires RSK |
 |--------|--------|----------|:------------:|
 | [`DirectGF()`](api-advanced.md#PhoXonic.DirectGF) | O(N²) | Small systems, high accuracy | No |
-| [`RSKGF()`](api-advanced.md#PhoXonic.RSKGF) | O(N²) | Many frequencies, 2D | Yes |
-| [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF) | O(N) | Large systems, 2D/3D | Yes |
+| [`RSKGF()`](api-advanced.md#PhoXonic.RSKGF) | O(N²) | Many frequencies | Yes |
+| [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF) | O(N) | Large systems | Yes |
+
+Which method a function accepts depends on the dimension; see
+[Dimension Support](#Dimension-Support).
 
 ### DirectGF
 
@@ -82,9 +85,9 @@ CGRHSInv(; atol=1e-10, rtol=1e-10, maxiter=100)
 
 ## Functions
 
-### [compute_greens_function](api-advanced.md#PhoXonic.compute_greens_function)
+### `compute_greens_function`
 
-Compute the Green's function G(ω) = (ω² - H)⁻¹ for multiple frequencies.
+Compute the Green's function G(ω) = (ω² - H)⁻¹ for multiple frequencies ([API reference](api-advanced.md#PhoXonic.compute_greens_function)).
 
 ```julia
 G_values = compute_greens_function(solver, k, ω_values, source, method; η=1e-3)
@@ -95,14 +98,16 @@ G_values = compute_greens_function(solver, k, ω_values, source, method; η=1e-3
 - `k`: Wave vector (e.g., `[0.0, 0.0]`)
 - `ω_values`: Vector of frequencies
 - `source`: Source vector in plane wave basis
-- `method`: `DirectGF()`, `RSKGF()`, or `MatrixFreeGF()`
+- `method`: a [`GFMethod`](api-advanced.md#PhoXonic.GFMethod); which ones are accepted depends on the dimension, see [Dimension Support](#Dimension-Support)
 - `η`: Broadening parameter (imaginary part of ω²)
 
 **Returns:** Vector of Green's function solutions, one for each frequency.
 
-### [compute_ldos](api-advanced.md#PhoXonic.compute_ldos)
+Available in every dimension.
 
-Compute the Local Density of States at a specific position.
+### `compute_ldos`
+
+Compute the Local Density of States at a specific position ([API reference](api-advanced.md#PhoXonic.compute_ldos)).
 
 ```julia
 ldos = compute_ldos(solver, position, ω_values, k_points, method; η=1e-3)
@@ -113,14 +118,16 @@ ldos = compute_ldos(solver, position, ω_values, k_points, method; η=1e-3)
 - `position`: Real-space position (e.g., `[0.5, 0.5]`)
 - `ω_values`: Vector of frequencies
 - `k_points`: Vector of k-points for BZ sampling
-- `method`: `DirectGF()`, `RSKGF()`, or `MatrixFreeGF()`
+- `method`: a [`GFMethod`](api-advanced.md#PhoXonic.GFMethod); 2D only, except [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF), which also works in 3D
 - `η`: Broadening parameter
 
 **Returns:** Vector of LDOS values for each frequency.
 
-### [compute_dos](api-advanced.md#PhoXonic.compute_dos)
+In 1D, omit the method: `compute_ldos(solver, position, ω_values, k_points)`.
 
-Compute the Density of States (stochastic trace method for RSKGF/MatrixFreeGF).
+### `compute_dos`
+
+Compute the Density of States (stochastic trace method for RSKGF/MatrixFreeGF) ([API reference](api-advanced.md#PhoXonic.compute_dos)).
 
 ```julia
 dos = compute_dos(solver, ω_values, k_points, method; η=1e-3, n_random=10)
@@ -130,11 +137,14 @@ dos = compute_dos(solver, ω_values, k_points, method; η=1e-3, n_random=10)
 - `solver`: Solver instance
 - `ω_values`: Vector of frequencies
 - `k_points`: Vector of k-points for BZ sampling
-- `method`: `DirectGF()`, `RSKGF()`, or `MatrixFreeGF()`
+- `method`: a [`GFMethod`](api-advanced.md#PhoXonic.GFMethod); 2D only
 - `η`: Broadening parameter
 - `n_random`: Number of random vectors for stochastic trace (RSKGF/MatrixFreeGF only)
 
 **Returns:** Vector of DOS values for each frequency.
+
+In 1D, omit the method: `compute_dos(solver, ω_values, k_points)`. There is no
+three-dimensional `compute_dos`.
 
 ## Examples
 
@@ -178,11 +188,39 @@ ldos_cg = compute_ldos(solver, position, ω_values, k_points,
 
 ## Dimension Support
 
-| Method | 1D | 2D | 3D |
-|--------|:--:|:--:|:--:|
-| [`DirectGF()`](api-advanced.md#PhoXonic.DirectGF) | Yes | Yes | No |
-| [`RSKGF()`](api-advanced.md#PhoXonic.RSKGF) | No | Yes | No |
-| [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF) | No | Yes | Yes |
+The three functions do not support the same dimensions, so the table is per
+function rather than per method. Each cell lists the
+[`GFMethod`](api-advanced.md#PhoXonic.GFMethod)s that the function accepts in that
+dimension; ✝ marks a method that further restricts the wave type.
+
+| Function | 1D | 2D | 3D |
+|----------|----|----|----|
+| [`compute_greens_function`](api-advanced.md#PhoXonic.compute_greens_function) | [`DirectGF()`](api-advanced.md#PhoXonic.DirectGF), [`RSKGF()`](api-advanced.md#PhoXonic.RSKGF) | every method | [`DirectGF()`](api-advanced.md#PhoXonic.DirectGF), [`RSKGF()`](api-advanced.md#PhoXonic.RSKGF), [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF)✝ |
+| [`compute_dos`](api-advanced.md#PhoXonic.compute_dos) | — (use the three-argument form) | every method | — |
+| [`compute_ldos`](api-advanced.md#PhoXonic.compute_ldos) | — (use the four-argument form) | every method | [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF)✝ only |
+
+An explicit [`GFMethod`](api-advanced.md#PhoXonic.GFMethod) is accepted by
+[`compute_dos`](api-advanced.md#PhoXonic.compute_dos) and
+[`compute_ldos`](api-advanced.md#PhoXonic.compute_ldos) only in 2D, and, for
+`compute_ldos`, in 3D with
+[`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF). In 1D, call them
+without a method:
+
+```julia
+dos = compute_dos(solver, ω_values, k_points)
+ldos = compute_ldos(solver, position, ω_values, k_points)
+```
+
+There is no three-dimensional `compute_dos`, with or without a method. Green's
+functions, by contrast, are available in every dimension.
+
+✝ [`MatrixFreeGF()`](api-advanced.md#PhoXonic.MatrixFreeGF) in 3D needs a wave
+type whose right-hand side can be inverted:
+[`FullVectorEM`](api-solver.md#PhoXonic.FullVectorEM) and
+[`FullElastic`](api-solver.md#PhoXonic.FullElastic), but not
+[`TransverseEM`](api-solver.md#PhoXonic.TransverseEM)
+([issue #72](https://github.com/hsugawa8651/PhoXonic.jl/issues/72)). This applies
+to both marked cells, `compute_greens_function` and `compute_ldos`.
 
 ## See Also
 

--- a/src/rscg.jl
+++ b/src/rscg.jl
@@ -1258,6 +1258,10 @@ end
 
 Compute density of states (DOS) using the specified method.
 
+This form is available for 2D solvers only. In 1D, use
+`compute_dos(solver, ω_values, k_points)`. There is no 3D method, with or without
+an explicit `GFMethod`.
+
 # Methods
 - `DirectGF()`: Dense direct solve (most accurate)
 - `RSKGF()`: Dense RSK with stochastic trace estimation
@@ -1354,6 +1358,11 @@ end
     compute_ldos(solver, position, ω_values, k_points, method::GFMethod; η=1e-3)
 
 Compute local density of states (LDOS) using the specified method.
+
+This form is available for 2D solvers, and in 3D for `MatrixFreeGF()` alone,
+where it also requires a wave type whose right-hand side can be inverted
+(`FullVectorEM` or `FullElastic`, not `TransverseEM`). In 1D, use
+`compute_ldos(solver, position, ω_values, k_points)`.
 
 # Methods
 - `DirectGF()`: Dense direct solve (most accurate, O(N²) memory)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -851,7 +851,11 @@ end
 """
     solve(solver::Solver, k; bands=1:10)
 
-Solve the eigenvalue problem at wave vector k.
+Solve the eigenvalue problem at the single wave vector `k`.
+
+One call yields the frequencies and modes at that one point of the Brillouin
+zone. To obtain a band structure, sweep a path of wave vectors with
+[`compute_bands`](@ref), which calls this function at each of them.
 
 # Arguments
 - `solver`: The solver
@@ -861,6 +865,10 @@ Solve the eigenvalue problem at wave vector k.
 # Returns
 - `frequencies`: Eigenfrequencies (sorted, positive)
 - `modes`: Corresponding eigenvectors
+
+!!! note
+    This is not the `solve(problem, algorithm)` entry point of the SciML idiom.
+    That is a design, and is not part of v0.3.0.
 """
 function solve(solver::Solver, k; bands=1:10)
     return solve_impl(solver, k, solver.method; bands=bands)


### PR DESCRIPTION
Closes #71. The commit message says what changed; this is what the PR leaves alone.

`greens_function.md` still restates the Arguments and Returns of the three
functions by hand, while the canonical docstrings render from `api-advanced.md`
(#76). This PR corrects that copy where it was wrong and leaves the duplication.
Rendering the docstrings here instead is not a one-line change: an `@docs` block
fails the build with `duplicate docs found for 'compute_dos'`, and `:docs_block`
is not in the `warnonly` list of `docs/make.jl:41`. Moving them out of the API
reference is a separate decision.

The new page writes out the nine `(D,W)` pairs a fourth time, after
`prepare_materials`, `build_matrices` and the unused `applicable_dimension`
(#73). Documenting them is the point of #71, but nothing generates the table from
the code and nothing checks it.

Two things fell out of the work. Clarifying that `solve` handles one wave vector
exposed how little separates it from `solve_at_k` and `solve_at_k_with_vectors`
(#77). And the three headings under `## Functions` were markdown links, which
produced nested `<a>` elements and ids containing raw markdown, with
`compute_greens_function` rendering as `computegreensfunction`; fixed here, since
the section was being rewritten anyway.

## Verification

- `docs/make.jl` builds; every anchor on both pages resolves; no nested `<a>` left.
- `Pkg.test()` core: 1650/1650. The `src/` diff is docstrings only.
- JuliaFormatter v2 reports no change. Version unchanged at 0.3.0. No other docs
  page modified.

