### PR TITLE
fix: normalize the wave vector at the solve entry points

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -845,6 +845,57 @@ function get_weight_matrix(solver::Solver{Dim3,FullElastic})
 end
 
 # ============================================================================
+# Wave vector normalization
+# ============================================================================
+
+# `solve` and `solve_at_k` descend into different stacks, and each used to accept a
+# different set of shapes for `k`.  `solve` took a scalar and a tuple but not a
+# one-element vector in 1D; `solve_at_k` took a vector but not a tuple, and not a
+# scalar when the method was KrylovKitMethod.  A shape that matched neither fell
+# through to a generic fallback that blamed the solver method.
+#
+# Every entry point now normalizes first: a wave vector is a real number in 1D and a
+# `Vector{Float64}` in 2D and 3D, whatever the caller wrote it as.
+
+_kdim(::Solver{Dim1}) = 1
+_kdim(::Solver{Dim2}) = 2
+_kdim(::Solver{Dim3}) = 3
+
+function _k_message(solver::Solver{D}, k) where {D}
+    n = _kdim(solver)
+    got = if k isa Union{Tuple,AbstractVector}
+        "a $(typeof(k)) of length $(length(k))"
+    else
+        "a $(typeof(k))"
+    end
+    n == 1 && return "The wave vector for a $(nameof(D)) solver must be a real number " *
+           "or a 1-element container. Got $got."
+    return "The wave vector for a $(nameof(D)) solver must have $n components. " *
+           "Got $got. Accepted forms: a $n-element vector, a $n-tuple, " *
+           "or an SVector{$n}."
+end
+
+_normalize_k(::Solver{Dim1}, k::Real) = Float64(k)
+
+function _normalize_k(solver::Solver{Dim1}, k::Union{Tuple,AbstractVector})
+    length(k) == 1 || throw(ArgumentError(_k_message(solver, k)))
+    return Float64(first(k))
+end
+
+function _normalize_k(solver::Solver{Dim2}, k::Union{Tuple,AbstractVector})
+    length(k) == 2 || throw(ArgumentError(_k_message(solver, k)))
+    return Float64[k[1], k[2]]
+end
+
+function _normalize_k(solver::Solver{Dim3}, k::Union{Tuple,AbstractVector})
+    length(k) == 3 || throw(ArgumentError(_k_message(solver, k)))
+    return Float64[k[1], k[2], k[3]]
+end
+
+# A scalar in 2D or 3D, or anything that is not a number or a container of numbers.
+_normalize_k(solver::Solver, k) = throw(ArgumentError(_k_message(solver, k)))
+
+# ============================================================================
 # Solve eigenvalue problem
 # ============================================================================
 
@@ -859,7 +910,9 @@ zone. To obtain a band structure, sweep a path of wave vectors with
 
 # Arguments
 - `solver`: The solver
-- `k`: Wave vector (in units of reciprocal lattice vectors or absolute)
+- `k`: Wave vector, with one component per dimension. Write it as a vector, a tuple or
+  an `SVector`; in 1D a bare real number is also accepted. The same shapes work at
+  every entry point and with every solver method.
 - `bands`: Which bands to return (default: 1:10)
 
 # Returns
@@ -871,26 +924,7 @@ zone. To obtain a band structure, sweep a path of wave vectors with
     That is a design, and is not part of v0.3.0.
 """
 function solve(solver::Solver, k; bands=1:10)
-    return solve_impl(solver, k, solver.method; bands=bands)
-end
-
-# Convenience method with SVector
-function solve(solver::Solver{Dim2}, k::SVector{2}; bands=1:10)
-    return solve(solver, Vector(k); bands=bands)
-end
-
-# Convenience method with tuple
-function solve(solver::Solver{Dim2}, k::Tuple{Real,Real}; bands=1:10)
-    return solve(solver, [Float64(k[1]), Float64(k[2])]; bands=bands)
-end
-
-# Convenience methods for 3D
-function solve(solver::Solver{Dim3}, k::SVector{3}; bands=1:10)
-    return solve(solver, Vector(k); bands=bands)
-end
-
-function solve(solver::Solver{Dim3}, k::Tuple{Real,Real,Real}; bands=1:10)
-    return solve(solver, [Float64(k[1]), Float64(k[2]), Float64(k[3])]; bands=bands)
+    return solve_impl(solver, _normalize_k(solver, k), solver.method; bands=bands)
 end
 
 # ============================================================================
@@ -907,7 +941,8 @@ For eigenvectors, use [`solve_at_k_with_vectors`](@ref) instead.
 
 # Arguments
 - `solver::Solver`: Solver instance
-- `k`: Wave vector (2D: Vector{Float64}, 1D: Float64)
+- `k`: Wave vector, with one component per dimension, in 1D, 2D or 3D. Write it as a
+  vector, a tuple or an `SVector`; in 1D a bare real number is also accepted.
 - `method::SolverMethod`: Solver method (DenseMethod, LOBPCGMethod, etc.)
 
 # Keyword Arguments
@@ -945,7 +980,9 @@ See also: [`solve_at_k_with_vectors`](@ref), [`solve`](@ref), [`matrix_dimension
 function solve_at_k(
     solver::Solver, k, method::SolverMethod; bands=1:10, X0=nothing, P=nothing
 )
-    frequencies, _ = _solve_at_k_impl(solver, k, method; bands=bands, X0=X0, P=P)
+    frequencies, _ = _solve_at_k_impl(
+        solver, _normalize_k(solver, k), method; bands=bands, X0=X0, P=P
+    )
     return frequencies
 end
 
@@ -960,7 +997,8 @@ overlaps, mode profiles, or topological invariants).
 
 # Arguments
 - `solver::AbstractSolver`: The solver object
-- `k`: Wave vector (Real for 1D, AbstractVector for 2D/3D)
+- `k`: Wave vector, with one component per dimension, in 1D, 2D or 3D. Write it as a
+  vector, a tuple or an `SVector`; in 1D a bare real number is also accepted.
 - `method::SolverMethod`: Solver method (DenseMethod(), KrylovKitMethod(), LOBPCGMethod())
 
 # Keyword Arguments
@@ -983,7 +1021,9 @@ See also: [`solve_at_k`](@ref), [`get_weight_matrix`](@ref), [`build_matrices`](
 function solve_at_k_with_vectors(
     solver::Solver, k, method::SolverMethod; bands=1:10, X0=nothing, P=nothing
 )
-    frequencies, eigenvectors = _solve_at_k_impl(solver, k, method; bands=bands, X0=X0, P=P)
+    frequencies, eigenvectors = _solve_at_k_impl(
+        solver, _normalize_k(solver, k), method; bands=bands, X0=X0, P=P
+    )
     return (frequencies, eigenvectors)
 end
 
@@ -1147,6 +1187,14 @@ This finds eigenvalues closest to σ, which is useful for:
 - Skipping spurious longitudinal modes in 3D H-field formulation
 - Targeting specific frequency ranges
 =#
+# In 1D the normalized wave vector is a real number, but the KrylovKit core works from
+# a vector of coordinates in every dimension.
+function _solve_krylovkit(
+    solver::Solver{Dim1,W}, k::Real, method::KrylovKitMethod, bands
+) where {W}
+    return _solve_krylovkit(solver, [Float64(k)], method, bands)
+end
+
 function _solve_krylovkit(
     solver::Solver{D,W}, k::Vector{Float64}, method::KrylovKitMethod, bands
 ) where {D,W}

--- a/test/dimension_guards_test.jl
+++ b/test/dimension_guards_test.jl
@@ -101,4 +101,108 @@ using PhoXonic
         s1 = Solver(Photonic1D(), geo1, (64,); cutoff=5)
         @test_throws "2D solvers only" compute_dos(s1, ω_values, [0.1, 0.2], DirectGF())
     end
+
+    @testset "a wave vector is the same wave vector at every entry point" begin
+        # solve and solve_at_k used to accept different shapes of k, in opposite
+        # directions, and a shape that matched neither was reported as an unsupported
+        # solver method.  Every shape now reaches every entry point.
+        #
+        # LOBPCGMethod appears in 2D only.  The 1D fixture here has a matrix dimension
+        # of 7, and asking for two bands puts LOBPCG's search block at 3*2 = 6 columns
+        # against those 7 rows.  There it breaks down: it throws, or it returns an
+        # eigenvalue that is not in the spectrum and reports convergence (#95).
+
+        function failure_message(f)
+            try
+                f()
+            catch e
+                return sprint(showerror, e)
+            end
+            return ""
+        end
+
+        @testset "1D: a scalar, a vector and a tuple agree" begin
+            for method in (DenseMethod(), KrylovKitMethod())
+                s = Solver(Photonic1D(), geo1, (16,), method; cutoff=3)
+                scalar, _ = solve(s, 0.3; bands=1:2)
+
+                @test solve(s, [0.3]; bands=1:2)[1] ≈ scalar
+                @test solve(s, (0.3,); bands=1:2)[1] ≈ scalar
+
+                # solve_at_k took a vector, but not a scalar with KrylovKitMethod.
+                @test solve_at_k(s, 0.3, method; bands=1:2) ≈ scalar
+                @test solve_at_k(s, [0.3], method; bands=1:2) ≈ scalar
+                @test solve_at_k(s, (0.3,), method; bands=1:2) ≈ scalar
+            end
+        end
+
+        @testset "2D: an integer Γ, a tuple and a vector agree" begin
+            # Normalization is a type conversion, so a deterministic method returns the
+            # same numbers whichever shape the caller wrote.  The iterative methods
+            # start from random vectors and do not repeat themselves at Γ, where the
+            # lowest TM band sits at zero; for those the point is that the call is
+            # accepted at all.
+            s_dense = Solver(TMWave(), geo2, (16, 16), DenseMethod(); cutoff=3)
+
+            gamma, _ = solve(s_dense, [0.0, 0.0]; bands=1:2)
+            @test solve(s_dense, [0, 0]; bands=1:2)[1] == gamma
+            @test solve_at_k(s_dense, [0, 0], DenseMethod(); bands=1:2) == gamma
+
+            k, _ = solve(s_dense, [0.1, 0.2]; bands=1:2)
+            @test solve(s_dense, (0.1, 0.2); bands=1:2)[1] == k
+            @test solve_at_k(s_dense, (0.1, 0.2), DenseMethod(); bands=1:2) == k
+
+            # _solve_krylovkit asks for a Vector{Float64}.  An integer Γ and a tuple
+            # used to reach it unconverted, or to reach build_matrices, which has no
+            # method for a tuple.
+            for method in (KrylovKitMethod(), LOBPCGMethod())
+                s = Solver(TMWave(), geo2, (16, 16), method; cutoff=3)
+
+                @test length(solve(s, [0, 0]; bands=1:2)[1]) == 2
+                @test length(solve(s, (0.1, 0.2); bands=1:2)[1]) == 2
+                @test length(solve_at_k(s, [0, 0], method; bands=1:2)) == 2
+                @test length(solve_at_k(s, (0.1, 0.2), method; bands=1:2)) == 2
+            end
+        end
+
+        @testset "3D: a tuple and a vector agree" begin
+            # DenseMethod only.  KrylovKitMethod is the matrix-free path, and it has no
+            # operator for TransverseEM, so it throws from inside KrylovKit before the
+            # wave vector matters.  LOBPCGMethod starts from random vectors and does not
+            # repeat itself, which is what the 2D testset above compares against.
+            s = Solver(TransverseEM(), geo3, (8, 8, 8), DenseMethod(); cutoff=2)
+            k, _ = solve(s, [0.1, 0.2, 0.3]; bands=1:2)
+
+            @test solve(s, (0.1, 0.2, 0.3); bands=1:2)[1] ≈ k
+            @test solve_at_k(s, (0.1, 0.2, 0.3), DenseMethod(); bands=1:2) ≈ k
+            @test solve_at_k_with_vectors(s, (0.1, 0.2, 0.3), DenseMethod(); bands=1:2)[1] ≈
+                k
+        end
+
+        @testset "the wrong number of components names the dimension, not the method" begin
+            s1 = Solver(Photonic1D(), geo1, (16,); cutoff=3)
+            s2 = Solver(TMWave(), geo2, (16, 16); cutoff=3)
+            s3 = Solver(TransverseEM(), geo3, (8, 8, 8), DenseMethod(); cutoff=2)
+
+            @test_throws ArgumentError solve(s2, [0.1]; bands=1:1)
+            @test_throws "must have 2 components" solve(s2, [0.1]; bands=1:1)
+            @test_throws "must have 2 components" solve(s2, 0.3; bands=1:1)
+            @test_throws "must have 3 components" solve_at_k(
+                s3, (0.1, 0.2), DenseMethod(); bands=1:1
+            )
+            @test_throws "must be a real number or a 1-element container" solve(
+                s1, [0.1, 0.2]; bands=1:1
+            )
+
+            # The message used to blame the solver method, and then list that same
+            # method among the supported ones.  It must not do that again.
+            for f in (
+                () -> solve(s2, [0.1]; bands=1:1),
+                () -> solve(s1, [0.1, 0.2]; bands=1:1),
+                () -> solve_at_k(s3, (0.1, 0.2), DenseMethod(); bands=1:1),
+            )
+                @test !occursin("Unsupported solver method", failure_message(f))
+            end
+        end
+    end
 end

--- a/test/test_midlevel_api.jl
+++ b/test/test_midlevel_api.jl
@@ -106,8 +106,13 @@ using LinearAlgebra
         @test_throws ErrorException solve_at_k_with_vectors(123, k, DenseMethod())
         @test_throws ErrorException solve_at_k_with_vectors("invalid", k, DenseMethod())
 
-        # Invalid k type
-        @test_throws ErrorException solve_at_k_with_vectors(
+        # Invalid k type.  The wave vector is normalized at the entry point, so this
+        # is now an ArgumentError naming the dimension and the accepted shapes,
+        # rather than an ErrorException blaming the solver method.
+        @test_throws ArgumentError solve_at_k_with_vectors(
+            solver_tm, "invalid", DenseMethod()
+        )
+        @test_throws "must have 2 components" solve_at_k_with_vectors(
             solver_tm, "invalid", DenseMethod()
         )
 


### PR DESCRIPTION
Closes #86. Closes #89.

One commit, e00b7fd. The reasons are in its body.

## Verification

- core: **1650 → 1684** (+34). ext: 50/50. `dimension_guards_test.jl` alone: 63/63.
- JuliaFormatter v2.10.1 clean. Version unchanged at 0.3.0.
- **No numbers move.** Normalization is a type conversion, and the new tests assert that
  with `==` on `DenseMethod`, which is deterministic.

## For review

- **The four convenience methods of `solve` are removed** (`SVector` and tuple, 2D and
  3D). Behaviour is unchanged and the tests cover those shapes. If you would rather keep
  them, say so; nothing else here depends on it.
- `test_midlevel_api.jl` pinned the old error type and is updated in the same commit. The
  `@test_throws` in `test_error_fallbacks.jl` pass a non-`Solver` first argument, reach
  the `Any` fallback, and are untouched — checked by hand.
- The tests avoid `LOBPCGMethod` in 1D (#95) and `KrylovKitMethod` in 3D (#90). The commit
  body says why.
