### PR TITLE
fix: centre the shifted FFT at N÷2+1 so odd resolutions work

### DIFF
--- a/src/convmat.jl
+++ b/src/convmat.jl
@@ -28,9 +28,11 @@ function convolution_matrix(f::AbstractMatrix, basis::PlaneWaveBasis{Dim2})
     # fftshift moves zero-frequency to center
     f_fft = fftshift(fft(fftshift(f))) / length(f)
 
-    # Center indices for accessing FFT result
-    cx = (Nx + 1) ÷ 2 + 1
-    cy = (Ny + 1) ÷ 2 + 1
+    # Where fftshift puts the zero frequency.  It is N ÷ 2 + 1, not (N + 1) ÷ 2 + 1:
+    # the two agree only for even N, and for odd N the second is one entry too far,
+    # which reads the wrong Fourier coefficients and leaves C non-Hermitian.
+    cx = Nx ÷ 2 + 1
+    cy = Ny ÷ 2 + 1
 
     # Build convolution matrix
     C = zeros(ComplexF64, N, N)
@@ -67,7 +69,7 @@ function convolution_matrix(f::AbstractVector, basis::PlaneWaveBasis{Dim1})
     f_fft = fftshift(fft(fftshift(f))) / Nx
 
     # Center index
-    cx = (Nx + 1) ÷ 2 + 1
+    cx = Nx ÷ 2 + 1
 
     # Build convolution matrix
     C = zeros(ComplexF64, N, N)
@@ -100,9 +102,9 @@ function convolution_matrix(f::AbstractArray{T,3}, basis::PlaneWaveBasis{Dim3}) 
     f_fft = fftshift(fft(fftshift(f))) / length(f)
 
     # Center indices
-    cx = (Nx + 1) ÷ 2 + 1
-    cy = (Ny + 1) ÷ 2 + 1
-    cz = (Nz + 1) ÷ 2 + 1
+    cx = Nx ÷ 2 + 1
+    cy = Ny ÷ 2 + 1
+    cz = Nz ÷ 2 + 1
 
     # Build convolution matrix
     C = zeros(ComplexF64, N, N)

--- a/src/matrixfree.jl
+++ b/src/matrixfree.jl
@@ -257,8 +257,8 @@ function fourier_to_grid!(
 ) where {T}
     fill!(grid, zero(T))
     Nx, Ny = resolution
-    cx = (Nx + 1) ÷ 2 + 1
-    cy = (Ny + 1) ÷ 2 + 1
+    cx = Nx ÷ 2 + 1
+    cy = Ny ÷ 2 + 1
 
     # Place coefficients in shifted grid (centered at cx, cy)
     for (i, (p, q)) in enumerate(basis.indices)
@@ -283,7 +283,7 @@ function fourier_to_grid!(
 ) where {T}
     fill!(grid, zero(T))
     N = resolution[1]
-    cx = (N + 1) ÷ 2 + 1
+    cx = N ÷ 2 + 1
 
     for (i, (p,)) in enumerate(basis.indices)
         ix = cx + p
@@ -304,9 +304,9 @@ function fourier_to_grid!(
 ) where {T}
     fill!(grid, zero(T))
     Nx, Ny, Nz = resolution
-    cx = (Nx + 1) ÷ 2 + 1
-    cy = (Ny + 1) ÷ 2 + 1
-    cz = (Nz + 1) ÷ 2 + 1
+    cx = Nx ÷ 2 + 1
+    cy = Ny ÷ 2 + 1
+    cz = Nz ÷ 2 + 1
 
     for (i, (p, q, r)) in enumerate(basis.indices)
         ix = cx + p
@@ -334,8 +334,8 @@ function grid_to_fourier!(
     resolution::NTuple{2,Int},
 ) where {T}
     Nx, Ny = resolution
-    cx = (Nx + 1) ÷ 2 + 1
-    cy = (Ny + 1) ÷ 2 + 1
+    cx = Nx ÷ 2 + 1
+    cy = Ny ÷ 2 + 1
 
     # FFT with same convention as convolution_matrix
     grid_fft = fftshift(fft(fftshift(grid))) / (Nx * Ny)
@@ -360,7 +360,7 @@ function grid_to_fourier!(
     resolution::NTuple{1,Int},
 ) where {T}
     N = resolution[1]
-    cx = (N + 1) ÷ 2 + 1
+    cx = N ÷ 2 + 1
 
     grid_fft = fftshift(fft(fftshift(grid))) / N
 
@@ -383,9 +383,9 @@ function grid_to_fourier!(
     resolution::NTuple{3,Int},
 ) where {T}
     Nx, Ny, Nz = resolution
-    cx = (Nx + 1) ÷ 2 + 1
-    cy = (Ny + 1) ÷ 2 + 1
-    cz = (Nz + 1) ÷ 2 + 1
+    cx = Nx ÷ 2 + 1
+    cy = Ny ÷ 2 + 1
+    cz = Nz ÷ 2 + 1
 
     grid_fft = fftshift(fft(fftshift(grid))) / (Nx * Ny * Nz)
 

--- a/test/dimension_guards_test.jl
+++ b/test/dimension_guards_test.jl
@@ -102,6 +102,40 @@ using PhoXonic
         @test_throws "2D solvers only" compute_dos(s1, ω_values, [0.1, 0.2], DirectGF())
     end
 
+    @testset "an odd resolution is a resolution" begin
+        # fftshift puts the zero frequency at N ÷ 2 + 1.  convolution_matrix looked for
+        # it at (N + 1) ÷ 2 + 1, which is the same entry only when N is even.  At an odd
+        # resolution it read the Fourier coefficients one entry off centre, the
+        # convolution matrix stopped being Hermitian, the mass matrix stopped being
+        # positive definite, and solve returned zeros for every band.
+        #
+        # FullVectorEM is left out: it has spurious longitudinal modes at ω ≈ 0 at every
+        # resolution, which is what its recommended `shift` exists to skip, so zeros
+        # there mean nothing about this.
+
+        for (wave, geo, res, k) in (
+            (Photonic1D(), geo1, r -> (r,), 0.3),
+            (TEWave(), geo2, r -> (r, r), [0.1, 0.2]),
+            (TMWave(), geo2, r -> (r, r), [0.1, 0.2]),
+            (SHWave(), geo2_el, r -> (r, r), [0.1, 0.2]),
+            (TransverseEM(), geo3, r -> (r, r, r), [0.1, 0.2, 0.3]),
+        )
+            odd, _ = solve(
+                Solver(wave, geo, res(13), DenseMethod(); cutoff=3), k; bands=1:3
+            )
+            even, _ = solve(
+                Solver(wave, geo, res(14), DenseMethod(); cutoff=3), k; bands=1:3
+            )
+
+            # It used to be [0.0, 0.0, 0.0].
+            @test all(odd .> 1e-6)
+
+            # Two neighbouring resolutions differ by discretization error, not by orders
+            # of magnitude.
+            @test maximum(abs.(odd .- even) ./ even) < 0.2
+        end
+    end
+
     @testset "a wave vector is the same wave vector at every entry point" begin
         # solve and solve_at_k used to accept different shapes of k, in opposite
         # directions, and a shape that matched neither was reported as an unsupported


### PR DESCRIPTION
Closes #93.

One commit, ab63b7d. Eighteen sites, one expression.

## Verification

- core: **1684 → 1694** (+10). ext: 50/50. Format clean.
- **No existing number moves**, and none can: the old and new expressions agree for even
  N, and no test or example builds a solver at an odd resolution. Every one of the ten
  new passes is a new assertion.
- Version unchanged at 0.3.0.

## For review

- The new testset compares resolution 13 against 14 for five wave types. `FullVectorEM`
  is left out; the commit body says why.
- `src/field.jl` has `div.(size(field) .+ 1, 2)`, which looks similar. It is a real-space
  pixel chosen to fix a phase, not an fftshift index, and is untouched.
- The chain that turned the broken operator into a plausible band structure of zeros — a
  bare `catch` around `eigen(Hermitian, Hermitian)` and a clamp of negative eigenvalues —
  is untouched and stays open as #92. This PR removes the cause, not the camouflage.
