### PR TITLE
fix: pair fftshift with ifftshift so the Fourier round trip is the identity

### DIFF
--- a/src/matrixfree.jl
+++ b/src/matrixfree.jl
@@ -240,7 +240,17 @@ end
 # Fourier space ↔ Grid space conversion
 # ============================================================================
 
-# Use same convention as convolution_matrix: fftshift(fft(fftshift(f)))
+# fourier_to_grid! and grid_to_fourier! must be exact inverses of each other, or the
+# matrix-free operator is not the operator the basis describes.  Starting from
+#
+#     g = fftshift(ifft(ifftshift(G)))
+#
+# and using ifftshift ∘ fftshift = id, the inverse is
+#
+#     G = fftshift(fft(ifftshift(g)))
+#
+# The inner shift is ifftshift, not fftshift.  The two are the same only for even N,
+# which is why every even resolution worked and every odd one did not (#93).
 # For coefficients: place in shifted grid, then ifftshift(ifft(ifftshift))
 
 """
@@ -270,7 +280,7 @@ function fourier_to_grid!(
     end
 
     # Transform to real space: ifftshift, then ifft, then fftshift
-    # This is inverse of: fftshift(fft(fftshift(f))) / N
+    # Inverse of grid_to_fourier!: fftshift(fft(ifftshift(g))) / N
     grid .= fftshift(ifft(ifftshift(grid))) * (Nx * Ny)
     return grid
 end
@@ -338,7 +348,7 @@ function grid_to_fourier!(
     cy = Ny ÷ 2 + 1
 
     # FFT with same convention as convolution_matrix
-    grid_fft = fftshift(fft(fftshift(grid))) / (Nx * Ny)
+    grid_fft = fftshift(fft(ifftshift(grid))) / (Nx * Ny)
 
     for (i, (p, q)) in enumerate(basis.indices)
         ix = cx + p
@@ -362,7 +372,7 @@ function grid_to_fourier!(
     N = resolution[1]
     cx = N ÷ 2 + 1
 
-    grid_fft = fftshift(fft(fftshift(grid))) / N
+    grid_fft = fftshift(fft(ifftshift(grid))) / N
 
     for (i, (p,)) in enumerate(basis.indices)
         ix = cx + p
@@ -387,7 +397,7 @@ function grid_to_fourier!(
     cy = Ny ÷ 2 + 1
     cz = Nz ÷ 2 + 1
 
-    grid_fft = fftshift(fft(fftshift(grid))) / (Nx * Ny * Nz)
+    grid_fft = fftshift(fft(ifftshift(grid))) / (Nx * Ny * Nz)
 
     for (i, (p, q, r)) in enumerate(basis.indices)
         ix = cx + p

--- a/test/dimension_guards_test.jl
+++ b/test/dimension_guards_test.jl
@@ -134,6 +134,48 @@ using PhoXonic
             # of magnitude.
             @test maximum(abs.(odd .- even) ./ even) < 0.2
         end
+
+        @testset "the matrix-free path agrees with the dense one" begin
+            # The first fix to this only corrected the centering index, and the tests
+            # for it ran DenseMethod alone.  The matrix-free operator, which is what a
+            # plain KrylovKitMethod() uses, stayed broken at odd resolutions because
+            # fourier_to_grid! and grid_to_fourier! were not inverses of each other.
+            #
+            # TransverseEM is left out: it has no matrix-free operator at all, at any
+            # resolution (#90).
+            for (wave, geo, res, k) in (
+                (Photonic1D(), geo1, r -> (r,), 0.3),
+                (TEWave(), geo2, r -> (r, r), [0.1, 0.2]),
+                (TMWave(), geo2, r -> (r, r), [0.1, 0.2]),
+            )
+                for r in (13, 14)
+                    dense, _ = solve(
+                        Solver(wave, geo, res(r), DenseMethod(); cutoff=3), k; bands=1:3
+                    )
+                    free, _ = solve(
+                        Solver(wave, geo, res(r), KrylovKitMethod(); cutoff=3), k; bands=1:3
+                    )
+                    @test maximum(abs.(free .- dense) ./ dense) < 1e-6
+                end
+            end
+        end
+
+        @testset "the Fourier round trip is the identity" begin
+            # fourier_to_grid! then grid_to_fourier! has to give back what went in.  It
+            # did not at an odd resolution: fftshift is its own inverse only for even N,
+            # and the forward transform used it where ifftshift belongs.
+            for r in (10, 11, 12, 13, 15, 16)
+                basis = Solver(TMWave(), geo2, (r, r); cutoff=3).basis
+                coeffs = randn(ComplexF64, basis.num_pw)
+                grid = zeros(ComplexF64, r, r)
+                back = zeros(ComplexF64, basis.num_pw)
+
+                PhoXonic.fourier_to_grid!(grid, coeffs, basis, (r, r))
+                PhoXonic.grid_to_fourier!(back, grid, basis, (r, r))
+
+                @test maximum(abs.(back .- coeffs)) / maximum(abs.(coeffs)) < 1e-12
+            end
+        end
     end
 
     @testset "a wave vector is the same wave vector at every entry point" begin


### PR DESCRIPTION
Closes #93. The first fix, #97, closed it with half of it still broken. This is the other
half.

One commit, c34f789. The reasons are in its body.

## Verification

- The round trip is the identity at odd resolutions now: **1e-16**, from 0.81–1.07.
- Matrix-free agrees with dense at resolutions 13 and 14: **1e-13**.
- core: **1694 → 1706** (+12). ext: 50/50. Format clean. Version unchanged at 0.3.0.
- **No existing number moves.**

## For review

- `src/convmat.jl` is deliberately untouched. The commit body says why.
- The new tests run the matrix-free path at an odd resolution, which is what #97's tests
  did not.
- `TransverseEM` is out of the matrix-free comparison: it has no matrix-free operator at
  any resolution (#90).
