### PR TITLE
test: include test_transverse_em.jl and make its comparison assert (#99)

### DIFF
--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -2010,6 +2010,9 @@
     # (dimension, wave type) coupling and analysis-function dimension guards
     include("dimension_guards_test.jl")
 
+    # TransverseEM (3D photonic): polarization basis, matrices, solve, FCC
+    include("test_transverse_em.jl")
+
     # Aqua.jl quality checks
     include("aqua_test.jl")
 end

--- a/test/test_transverse_em.jl
+++ b/test/test_transverse_em.jl
@@ -92,7 +92,7 @@ using StaticArrays
 
         geo = Geometry(lat, air, [(Sphere([0.0, 0.0, 0.0], 0.2), dielectric),])
 
-        resolution = (4, 4, 4)
+        resolution = (10, 10, 10)
         cutoff = 2
 
         # Need FullVectorEM solver to get basis (TransverseEM not yet implemented)
@@ -126,7 +126,7 @@ using StaticArrays
 
         geo = Geometry(lat, air, [(Sphere([0.0, 0.0, 0.0], 0.2), dielectric),])
 
-        resolution = (4, 4, 4)
+        resolution = (10, 10, 10)
         cutoff = 2
 
         solver = Solver(TransverseEM(), geo, resolution, DenseMethod(); cutoff=cutoff)
@@ -193,7 +193,7 @@ using StaticArrays
 
         geo = Geometry(lat, air, [(Sphere([0.0, 0.0, 0.0], 0.2), dielectric),])
 
-        resolution = (4, 4, 4)
+        resolution = (10, 10, 10)
         cutoff = 2
         solver = Solver(TransverseEM(), geo, resolution, DenseMethod(); cutoff=cutoff)
         N = solver.basis.num_pw
@@ -240,11 +240,18 @@ using StaticArrays
             solver_full = Solver(
                 FullVectorEM(), geo, resolution, DenseMethod(); cutoff=cutoff
             )
-            freqs_full, _ = solve(solver_full, k; bands=1:10)
+            # FullVectorEM carries num_pw spurious longitudinal modes at omega=0,
+            # so the physical modes only begin at index num_pw+1. bands=1:10 never
+            # reached them: the filter came back empty and this comparison asserted
+            # nothing at all. Reach past the longitudinal block.
+            freqs_full, _ = solve(solver_full, k; bands=1:(N + 4))
             freqs_full_physical = filter(f -> f > 0.01, freqs_full)
 
+            # Guard: keep this comparison from silently going vacuous again
+            @test length(freqs_full_physical) >= 4
+
             # First few physical modes should match
-            for i in 1:min(4, length(freqs_full_physical))
+            for i in 1:4
                 @test freqs_trans[i] ≈ freqs_full_physical[i] rtol=0.01
             end
         end
@@ -263,7 +270,7 @@ using StaticArrays
         geo = Geometry(lat, air, [(Sphere([0.0, 0.0, 0.0], 0.25), dielectric),])
 
         # Use moderate resolution for tests
-        resolution = (8, 8, 8)
+        resolution = (18, 18, 18)
         cutoff = 4
 
         solver = Solver(TransverseEM(), geo, resolution, DenseMethod(); cutoff=cutoff)
@@ -310,7 +317,7 @@ using StaticArrays
         k_test = [0.5, 0.25, 0.0]  # General k-point
 
         # Test at different resolutions
-        resolutions = [(4, 4, 4), (6, 6, 6), (8, 8, 8)]
+        resolutions = [(14, 14, 14), (16, 16, 16), (18, 18, 18)]
         cutoff = 3
 
         freqs_at_res = Float64[]


### PR DESCRIPTION
Closes #99.

Test-only; `src/` is untouched. The reasons for each change are in the commit body.

## Why variant B for the resolutions

Three fixture sets were tried before choosing. All of them keep every assertion
passing:

| variant | fixtures | result |
|---|---|---|
| current | `(4,4,4)`c2 / `(8,8,8)`c4 / `[(4,4,4),(6,6,6),(8,8,8)]`c3 | all pass |
| A, clears the error band only | `(6,6,6)`c2 / `(10,10,10)`c4 / `[(8,8,8),(10,10,10),(12,12,12)]`c3 | all pass |
| **B, clears error and warn** | `(10,10,10)`c2 / `(18,18,18)`c4 / `[(14,14,14),(16,16,16),(18,18,18)]`c3 | all pass |

B costs no more than A: the cost is set by the basis size, and raising the
resolution only enlarges the `prepare_materials` FFT grid. B is the variant that
leaves no `@warn` behind once the guard of #91/#94 lands.

Two assertions looked fragile under a resolution change and both survive:
`"Resolution convergence"` and the `rtol=0.01` in the `FullVectorEM` comparison.

## Test counts

core goes from **1706** to **1802** (+96: 91 already in the file, 4 from the
comparison loop, 1 length guard).

Verified with `Pkg.test(; test_args=["core"])`. Format is clean under JuliaFormatter
2.10.2.

## Not in scope

W5b, the `resolution` guard of #91 and #94, is a separate PR.
