### PR TITLE
feat: add MultiphysicsMaterial and reject incoherent material fields

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -25,6 +25,7 @@ reciprocal_vectors
 ```@docs
 Dielectric
 IsotropicElastic
+MultiphysicsMaterial
 from_E_ν
 ```
 

--- a/docs/src/tmm.md
+++ b/docs/src/tmm.md
@@ -81,6 +81,11 @@ Supported materials:
 - `Dielectric(ε)` - lossless dielectric
 - `LossyDielectric(ε)` - complex permittivity for absorption
 - `IsotropicElastic(ρ, λ, μ)` - elastic material for phononic waves
+- `MultiphysicsMaterial(photonic, elastic)` - both parameter sets, so one stack
+  serves `Photonic1D` and `Longitudinal1D` alike
+
+All layers of a `Multilayer` have to carry the same kind of material; a stack that
+mixes an electromagnetic layer with an elastic one is rejected at construction.
 
 ### Multilayer
 

--- a/examples/000_examples.md
+++ b/examples/000_examples.md
@@ -46,6 +46,7 @@ Last-Modified: 2025-12-24
 | 212_kushwaha1993_fig2.jl | Kushwaha 1993 Fig.2: Ni/Al square lattice (different f) |
 | 213_tanaka2000_vacuum_al.jl | Tanaka 2000: Al/vacuum (Tanaka limit validation) |
 | 214_maldovan2006_phoxonic.jl | Maldovan 2006: Phoxonic crystal (Si/air) |
+| 214b_maldovan2006_multiphysics_geometry.jl | The same structure from one MultiphysicsMaterial geometry |
 | 216_si_epoxy_square.jl | Dobrzynski 2017 Ch.5 Fig.20A: Si/Epoxy square lattice |
 | 217_carbon_epoxy_square_section.jl | Dobrzynski 2017 Ch.5 Fig.3A: C/Epoxy square-section |
 | 218_carbon_epoxy_square.jl | Dobrzynski 2017 Ch.5 Fig.2A: C/Epoxy circle |

--- a/examples/214b_maldovan2006_multiphysics_geometry.jl
+++ b/examples/214b_maldovan2006_multiphysics_geometry.jl
@@ -1,0 +1,336 @@
+# 214b_maldovan2006_multiphysics_geometry.jl
+# Simultaneous photonic and phononic band gaps in the same structure
+#
+# Reference: Maldovan & Thomas, Appl. Phys. B 83, 595 (2006)
+# DOI: https://doi.org/10.1007/s00340-006-2241-y
+# "Simultaneous complete elastic and electromagnetic band gaps in periodic structures"
+#
+# Structure: Air holes in Si, triangular lattice, r/a = 0.46
+# Figure 3: Simultaneous photonic (a) and phononic (b) band gaps
+
+using Pkg
+Pkg.activate(joinpath(@__DIR__, ".."))
+
+using PhoXonic
+using Plots
+default(;
+    guidefontsize=14,
+    tickfontsize=12,
+    titlefontsize=14,
+    left_margin=10Plots.mm,
+    right_margin=10Plots.mm,
+    top_margin=5Plots.mm,
+    bottom_margin=10Plots.mm,
+)
+
+println("=" ^ 70)
+println("Maldovan 2006: Simultaneous Photonic-Phononic Band Gaps")
+println("=" ^ 70)
+
+# =============================================================================
+# Material Parameters: Silicon
+# =============================================================================
+
+# Silicon - Photonic properties
+ε_si = 13.0  # Relative permittivity (n ≈ 3.6)
+
+# Silicon - Phononic properties
+ρ_si = 2330.0   # kg/m³
+c_T = 5360.0    # m/s (transverse velocity)
+c_L = 8950.0    # m/s (longitudinal velocity)
+
+# Convert to Lamé parameters
+μ_si = ρ_si * c_T^2
+λ_si = ρ_si * (c_L^2 - 2 * c_T^2)
+
+# Create materials. Each region carries both parameter sets, so one geometry
+# serves the photonic and the phononic calculation alike.
+si = MultiphysicsMaterial(Dielectric(ε_si), IsotropicElastic(; ρ=ρ_si, λ=λ_si, μ=μ_si))
+air_void = MultiphysicsMaterial(Dielectric(1.0), ElasticVoid())
+
+println("\nMaterials:")
+println("  Si (photonic): ε = $ε_si")
+println("  Si (phononic): ρ = $ρ_si kg/m³, c_T = $c_T m/s, c_L = $c_L m/s")
+println("  Air/Void: ε = 1.0, ElasticVoid (Tanaka limit)")
+
+# =============================================================================
+# Geometry: Triangular lattice, r/a = 0.46
+# =============================================================================
+
+a = 1.0
+r_over_a = 0.46
+
+lat = hexagonal_lattice(a)
+geo = Geometry(lat, si, [(Circle([0.0, 0.0], r_over_a * a), air_void)])
+
+println("\nGeometry:")
+println("  Lattice: Triangular (hexagonal)")
+println("  r/a = $r_over_a")
+println("  Structure: Air/vacuum holes in Si matrix")
+
+# =============================================================================
+# Compute band structures
+# =============================================================================
+
+resolution = (64, 64)
+cutoff = 8
+n_bands = 10
+
+println("\nSolver: resolution=$resolution, cutoff=$cutoff")
+
+kpath = simple_kpath_hexagonal(; npoints=50)
+
+# --- Photonic ---
+println("\n--- Photonic Bands ---")
+println("  TE...")
+solver_te = Solver(TEWave(), geo, resolution; cutoff=cutoff)
+@time bands_te = compute_bands(solver_te, kpath; bands=1:n_bands)
+
+println("  TM...")
+solver_tm = Solver(TMWave(), geo, resolution; cutoff=cutoff)
+@time bands_tm = compute_bands(solver_tm, kpath; bands=1:n_bands)
+
+# --- Phononic ---
+println("\n--- Phononic Bands ---")
+println("  SH (out-of-plane)...")
+solver_sh = Solver(SHWave(), geo, resolution; cutoff=cutoff)
+@time bands_sh = compute_bands(solver_sh, kpath; bands=1:n_bands)
+
+println("  PSV (in-plane)...")
+solver_psv = Solver(PSVWave(), geo, resolution; cutoff=cutoff)
+@time bands_psv = compute_bands(solver_psv, kpath; bands=1:n_bands)
+
+# =============================================================================
+# Normalize frequencies
+# =============================================================================
+
+# Photonic: Convert from ωa/c to ωa/2πc
+freqs_te = bands_te.frequencies / (2π)
+freqs_tm = bands_tm.frequencies / (2π)
+
+# Phononic: ωa/2πc_T
+norm_phononic = 1.0 / (2π * c_T)
+freqs_sh = bands_sh.frequencies * norm_phononic
+freqs_psv = bands_psv.frequencies * norm_phononic
+
+# =============================================================================
+# Band Gap Analysis
+# =============================================================================
+
+println("\n" * "=" ^ 70)
+println("Band Gap Analysis")
+println("=" ^ 70)
+
+# Photonic gaps (need to normalize by 2π)
+println("\n--- Photonic Gaps (ωa/2πc) ---")
+te_gaps = find_all_gaps(bands_te)
+tm_gaps = find_all_gaps(bands_tm)
+
+println("TE gaps:")
+for gap in te_gaps
+    lower = gap.max_lower / (2π)
+    upper = gap.min_upper / (2π)
+    if lower < 1.0
+        println(
+            "  Band $(gap.bands): $(round(lower, digits=3)) - $(round(upper, digits=3))"
+        )
+    end
+end
+
+println("TM gaps:")
+for gap in tm_gaps
+    lower = gap.max_lower / (2π)
+    upper = gap.min_upper / (2π)
+    if lower < 1.0
+        println(
+            "  Band $(gap.bands): $(round(lower, digits=3)) - $(round(upper, digits=3))"
+        )
+    end
+end
+
+# Find complete photonic gap (TE ∩ TM overlap)
+te_gap_1 =
+    isempty(te_gaps) ? nothing : (te_gaps[1].max_lower / (2π), te_gaps[1].min_upper / (2π))
+tm_gap_2 = if length(tm_gaps) >= 2
+    (tm_gaps[2].max_lower / (2π), tm_gaps[2].min_upper / (2π))
+else
+    nothing
+end
+if te_gap_1 !== nothing && tm_gap_2 !== nothing
+    overlap_lower = max(te_gap_1[1], tm_gap_2[1])
+    overlap_upper = min(te_gap_1[2], tm_gap_2[2])
+    if overlap_lower < overlap_upper
+        println(
+            "\nComplete photonic gap (TE∩TM): $(round(overlap_lower, digits=3)) - $(round(overlap_upper, digits=3))",
+        )
+    end
+end
+
+println("Expected (Maldovan 2006 Fig.3a): Complete photonic gap = 0.408 - 0.464")
+
+# Phononic gaps
+println("\n--- Phononic Gaps (ωa/2πcT) ---")
+sh_gaps = find_all_gaps(bands_sh)
+psv_gaps = find_all_gaps(bands_psv)
+
+println("SH (out-of-plane) gaps:")
+for gap in sh_gaps
+    lower = gap.max_lower * norm_phononic
+    upper = gap.min_upper * norm_phononic
+    if lower < 2.0
+        println(
+            "  Band $(gap.bands): $(round(lower, digits=3)) - $(round(upper, digits=3))"
+        )
+    end
+end
+
+println("PSV (in-plane) gaps:")
+for gap in psv_gaps
+    lower = gap.max_lower * norm_phononic
+    upper = gap.min_upper * norm_phononic
+    if lower < 2.0
+        println(
+            "  Band $(gap.bands): $(round(lower, digits=3)) - $(round(upper, digits=3))"
+        )
+    end
+end
+
+println("\nExpected (Maldovan 2006 Fig.3b): Complete phononic gap = 0.830 - 0.963")
+
+# =============================================================================
+# Helper function to draw structure
+# =============================================================================
+function draw_circle!(p, cx, cy, r; color=:blue, fillalpha=1.0, n=100)
+    θ = range(0, 2π; length=n)
+    xs = cx .+ r .* cos.(θ)
+    ys = cy .+ r .* sin.(θ)
+    return plot!(
+        p,
+        xs,
+        ys;
+        seriestype=:shape,
+        fillcolor=color,
+        fillalpha=fillalpha,
+        linecolor=color,
+        linewidth=0.5,
+        label="",
+    )
+end
+
+# =============================================================================
+# Plot: Structure + 2x2 band diagrams
+# =============================================================================
+
+dists = bands_te.distances
+labels = bands_te.labels
+label_pos = [dists[i] for (i, _) in labels]
+label_names = [l for (_, l) in labels]
+
+# Expected gap regions from paper
+photonic_gap = (0.408, 0.464)  # Complete photonic gap
+phononic_gap = (0.830, 0.963)  # Complete phononic gap
+
+# --- Structure plot ---
+a1 = lat.vectors[1]
+a2 = lat.vectors[2]
+
+p_struct = plot(;
+    aspect_ratio=:equal,
+    xlabel="x/a",
+    ylabel="y/a",
+    title="Structure",
+    xlim=(-0.6, 1.6),
+    ylim=(-0.6, 1.2),
+    legend=false,
+    grid=false,
+    background_color_inside=:steelblue,  # Si background
+)
+
+# Draw air holes at visible unit cells
+for di in -1:2
+    for dj in -1:2
+        offset = di * a1 + dj * a2
+        cx = 0.0 + offset[1]
+        cy = 0.0 + offset[2]
+        draw_circle!(p_struct, cx, cy, r_over_a; color=:white, fillalpha=1.0)
+    end
+end
+
+# Draw unit cell boundary
+corners = [[0.0, 0.0], collect(a1), collect(a1 + a2), collect(a2), [0.0, 0.0]]
+plot!(
+    p_struct,
+    [c[1] for c in corners],
+    [c[2] for c in corners];
+    color=:black,
+    linewidth=2,
+    linestyle=:dash,
+    label="",
+)
+
+# Add material labels
+annotate!(p_struct, 0.8, 0.9, text("Si", :white, 12))
+annotate!(p_struct, 0.0, 0.0, text("Air", :gray, 10))
+
+# --- TE subplot ---
+p1 = plot(; ylabel="ωa/2πc", title="TE (photonic)", legend=false, grid=true, ylims=(0, 0.8))
+for b in 1:size(freqs_te, 2)
+    plot!(p1, dists, freqs_te[:, b]; lw=2, color=:blue, label="")
+end
+hspan!(p1, [photonic_gap...]; alpha=0.3, color=:green, label="")
+vline!(p1, label_pos; color=:gray, ls=:dash, alpha=0.5, label="")
+xticks!(p1, label_pos, label_names)
+
+# --- TM subplot ---
+p2 = plot(; title="TM (photonic)", legend=false, grid=true, ylims=(0, 0.8))
+for b in 1:size(freqs_tm, 2)
+    plot!(p2, dists, freqs_tm[:, b]; lw=2, color=:red, label="")
+end
+hspan!(p2, [photonic_gap...]; alpha=0.3, color=:green, label="")
+vline!(p2, label_pos; color=:gray, ls=:dash, alpha=0.5, label="")
+xticks!(p2, label_pos, label_names)
+
+# --- SH subplot ---
+p3 = plot(;
+    ylabel="ωa/2πcT", title="SH (phononic)", legend=false, grid=true, ylims=(0, 1.5)
+)
+for b in 1:size(freqs_sh, 2)
+    plot!(p3, dists, freqs_sh[:, b]; lw=2, color=:forestgreen, label="")
+end
+hspan!(p3, [phononic_gap...]; alpha=0.3, color=:orange, label="")
+vline!(p3, label_pos; color=:gray, ls=:dash, alpha=0.5, label="")
+xticks!(p3, label_pos, label_names)
+
+# --- PSV subplot ---
+p4 = plot(; title="PSV (phononic)", legend=false, grid=true, ylims=(0, 1.5))
+for b in 1:size(freqs_psv, 2)
+    plot!(p4, dists, freqs_psv[:, b]; lw=2, color=:darkorange, label="")
+end
+hspan!(p4, [phononic_gap...]; alpha=0.3, color=:orange, label="")
+vline!(p4, label_pos; color=:gray, ls=:dash, alpha=0.5, label="")
+xticks!(p4, label_pos, label_names)
+
+# --- Combined layout: structure on left, 2x2 bands on right ---
+# Use @layout macro for custom layout
+lay = @layout [a{0.35w} grid(2, 2)]
+p = plot(
+    p_struct,
+    p1,
+    p2,
+    p3,
+    p4;
+    layout=lay,
+    size=(1400, 800),
+    plot_title="Maldovan 2006: PhoXonic Crystal - Si with Air Holes (r/a=0.46)",
+    left_margin=5Plots.mm,
+    bottom_margin=5Plots.mm,
+)
+
+savefig(p, joinpath(@__DIR__, "214b_maldovan2006_multiphysics_geometry.png"))
+println("\nSaved: 214b_maldovan2006_multiphysics_geometry.png")
+
+println("\n" * "=" ^ 70)
+println("This structure is 'deaf and blind' - it has simultaneous")
+println("complete photonic AND phononic band gaps!")
+println("=" ^ 70)
+println("\nReference: Maldovan & Thomas, Appl. Phys. B 83, 595 (2006)")

--- a/src/PhoXonic.jl
+++ b/src/PhoXonic.jl
@@ -70,6 +70,7 @@ export reciprocal_vectors
 # Exports - Materials
 export Material, PhotonicMaterial, ElasticMaterial
 export Dielectric, LossyDielectric, IsotropicElastic, ElasticVoid, from_E_ν
+export MultiphysicsMaterial
 export permittivity, permeability, refractive_index
 export density, shear_modulus, transverse_velocity, longitudinal_velocity
 

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -38,6 +38,39 @@ function Geometry(lattice::Lattice{D}, background::M) where {D<:Dimension,M<:Mat
 end
 
 """
+    _material_class(::Material) -> Symbol
+
+Which parameter set a material carries: `:photonic`, `:elastic`, or `:multiphysics`.
+
+A geometry describes which material fields are defined over the whole unit cell, so
+every region has to carry the same set. Note that a legal mixture can still promote
+to an abstract type (`IsotropicElastic` with `ElasticVoid` promotes to
+`ElasticMaterial`), which is why the class is asked of each material separately
+rather than read off the promoted type.
+"""
+_material_class(::PhotonicMaterial) = :photonic
+_material_class(::ElasticMaterial) = :elastic
+_material_class(::MultiphysicsMaterial) = :multiphysics
+
+function _assert_same_material_class(background::Material, inclusions)
+    bg = _material_class(background)
+    for (i, (_, mat)) in enumerate(inclusions)
+        cls = _material_class(mat)
+        cls === bg && continue
+        throw(
+            ArgumentError(
+                "Cannot mix material classes in one Geometry: the background is " *
+                "$bg ($(nameof(typeof(background)))), but inclusion $i is $cls " *
+                "($(nameof(typeof(mat)))). A geometry has to define the same " *
+                "material fields everywhere. Use MultiphysicsMaterial to give a " *
+                "region both electromagnetic and elastic parameters.",
+            ),
+        )
+    end
+    return nothing
+end
+
+"""
     Geometry(lattice, background, inclusions)
 
 Create a geometry with inclusions.
@@ -45,6 +78,7 @@ Create a geometry with inclusions.
 function Geometry(
     lattice::Lattice{D}, background::M, inclusions::Vector{<:Tuple{<:Shape{D},M2}}
 ) where {D,M<:Material,M2<:Material}
+    _assert_same_material_class(background, inclusions)
     # Ensure all materials have compatible types
     MT = promote_type(M, M2)
     incl = Vector{Tuple{Shape{D},MT}}([(s, convert(MT, m)) for (s, m) in inclusions])
@@ -79,6 +113,8 @@ function Geometry(
             )
         end
     end
+    # Dimensions check out; the material field has to be coherent too
+    _assert_same_material_class(background, inclusions)
     # If dimensions all match, use promote_type for mixed materials
     MT = promote_type(M, M2)
     typed_incl = Vector{Tuple{Shape{D},MT}}([(s, convert(MT, m)) for (s, m) in inclusions])
@@ -411,6 +447,21 @@ function get_property(mat::Dielectric, property::Symbol)
         return 1.0 / mat.μ
     else
         error("Unknown property $property for Dielectric")
+    end
+end
+
+# The complete set of properties `discretize` ever asks for, split by family.
+# See src/solver.jl and the discretize calls below: nothing else is requested.
+const _PHOTONIC_PROPERTIES = (:ε, :μ, :ε_inv, :μ_inv)
+const _ELASTIC_PROPERTIES = (:ρ, :C11, :C12, :C44)
+
+function get_property(mat::MultiphysicsMaterial, property::Symbol)
+    if property in _PHOTONIC_PROPERTIES
+        return get_property(mat.photonic, property)
+    elseif property in _ELASTIC_PROPERTIES
+        return get_property(mat.elastic, property)
+    else
+        error("Unknown property $property for MultiphysicsMaterial")
     end
 end
 

--- a/src/material.jl
+++ b/src/material.jl
@@ -280,6 +280,42 @@ For Tanaka limit: v_T → ∞ as ρ → 0.
 transverse_velocity(m::ElasticVoid) = sqrt(m.C44 / m.ρ)
 
 # ============================================================================
+# Multiphysics Material
+# ============================================================================
+
+"""
+    MultiphysicsMaterial(photonic, elastic)
+    MultiphysicsMaterial(elastic, photonic)
+
+A material carrying both electromagnetic and elastic parameters, so that one
+`Geometry` can be handed to photonic and phononic wave types alike.
+
+Both argument orders construct the same object: the fields are always stored as
+`photonic` and `elastic`. Two materials of the same family do not construct.
+
+This does not couple the two physics. It only says that both parameter sets are
+defined over the same region; the wave equations remain independent.
+
+# Examples
+
+```julia
+si = MultiphysicsMaterial(
+    Dielectric(11.7),
+    IsotropicElastic(2330.0, 165.7e9, 63.9e9, 79.6e9),
+)
+air_void = MultiphysicsMaterial(Dielectric(1.0), ElasticVoid())
+```
+"""
+struct MultiphysicsMaterial{P<:PhotonicMaterial,E<:ElasticMaterial} <: Material
+    photonic::P
+    elastic::E
+end
+
+# Accept the reversed argument order. PhotonicMaterial and ElasticMaterial are
+# disjoint, so this cannot be ambiguous with the default constructor.
+MultiphysicsMaterial(e::ElasticMaterial, p::PhotonicMaterial) = MultiphysicsMaterial(p, e)
+
+# ============================================================================
 # Type Promotion for Mixed Elastic Materials
 # ============================================================================
 
@@ -290,6 +326,15 @@ Base.promote_rule(::Type{ElasticVoid}, ::Type{IsotropicElastic}) = ElasticMateri
 # Convert to common supertype
 Base.convert(::Type{ElasticMaterial}, x::IsotropicElastic) = x
 Base.convert(::Type{ElasticMaterial}, x::ElasticVoid) = x
+
+# Two multiphysics materials rarely share both parameter types: a void background
+# with a solid inclusion is the ordinary case. Fall back to the abstract type rather
+# than let the default rule drop a type parameter.
+function Base.promote_rule(::Type{<:MultiphysicsMaterial}, ::Type{<:MultiphysicsMaterial})
+    return MultiphysicsMaterial
+end
+
+Base.convert(::Type{MultiphysicsMaterial}, x::MultiphysicsMaterial) = x
 
 # Error fallback for invalid Dielectric constructor arguments
 function Dielectric(args...)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -40,6 +40,36 @@ struct Solver{D<:Dimension,W<:WaveType,M<:SolverMethod} <: AbstractSolver
 end
 
 """
+    _required_material_class(::WaveType) -> Symbol
+
+Which material parameters a wave family needs: `:photonic` or `:elastic`.
+"""
+_required_material_class(::PhotonicWave) = :photonic
+_required_material_class(::PhononicWave) = :elastic
+
+"""
+    _assert_wave_matches_geometry(wave, geometry)
+
+Reject a wave family the geometry has no parameters for, before any material array
+is built. A geometry is class-coherent by construction, so the background speaks for
+all of it. `MultiphysicsMaterial` satisfies either family.
+"""
+function _assert_wave_matches_geometry(wave::WaveType, geometry::Geometry)
+    have = _material_class(geometry.background)
+    have === :multiphysics && return nothing
+    need = _required_material_class(wave)
+    have === need && return nothing
+    return throw(
+        ArgumentError(
+            "$(nameof(typeof(wave))) needs $need material parameters, but this " *
+            "geometry is $have ($(nameof(typeof(geometry.background)))). Build the " *
+            "geometry from $need materials, or from MultiphysicsMaterial to serve " *
+            "both wave families.",
+        ),
+    )
+end
+
+"""
     Solver(wave, geometry, resolution, [method]; cutoff=7, discretization=SimpleGrid())
 
 Create a solver for the given wave type and geometry.
@@ -74,6 +104,7 @@ function Solver(
     cutoff::Int=7,
     discretization::DiscretizationMethod=SimpleGrid(),
 ) where {D<:Dimension,W<:WaveType,N,M<:SolverMethod}
+    _assert_wave_matches_geometry(wave, geometry)
     basis = PlaneWaveBasis(geometry.lattice, cutoff)
     material_arrays = prepare_materials(wave, geometry, resolution, discretization)
     return Solver{D,W,M}(wave, geometry, basis, resolution, material_arrays, method)

--- a/src/tmm/bands.jl
+++ b/src/tmm/bands.jl
@@ -249,7 +249,9 @@ function tmm_bandstructure(
     # Estimate ω_max if not provided
     # For phononic crystal, ω ~ c*k, use c_max for upper bound
     if ω_max === nothing
-        c_max = maximum(longitudinal_velocity(layer.material) for layer in ml.layers)
+        c_max = maximum(
+            longitudinal_velocity(_elastic_of(layer.material)) for layer in ml.layers
+        )
         ω_max = 2π * maximum(band_range) / a * c_max * 1.5
     end
 
@@ -286,7 +288,11 @@ end
 Find frequencies where Tr(M_acoustic(ω)) = target for phononic crystals.
 """
 function find_band_frequencies_acoustic(
-    ml::Multilayer{<:ElasticMaterial}, target::Real, nbands::Int, ω_max::Real, a::Real
+    ml::Multilayer{<:Union{ElasticMaterial,MultiphysicsMaterial}},
+    target::Real,
+    nbands::Int,
+    ω_max::Real,
+    a::Real,
 )
     # Number of points to sweep
     nω = 2000
@@ -297,7 +303,8 @@ function find_band_frequencies_acoustic(
     # We need average velocity for wavelength conversion
     c_avg =
         sum(
-            longitudinal_velocity(layer.material) * thickness(layer) for layer in ml.layers
+            longitudinal_velocity(_elastic_of(layer.material)) * thickness(layer) for
+            layer in ml.layers
         ) / a
 
     trace_values = zeros(nω)

--- a/src/tmm/layers.jl
+++ b/src/tmm/layers.jl
@@ -61,8 +61,38 @@ struct Multilayer{M<:Material}
     substrate::M
 end
 
+"""
+    _assert_same_material_class_stack(incident, substrate, layers)
+
+Reject a stack that mixes material classes. Same rule as `Geometry`: a structure has
+to define the same material fields throughout, so that the wave family it is handed
+to finds parameters everywhere.
+"""
+function _assert_same_material_class_stack(incident::Material, substrate::Material, layers)
+    want = _material_class(incident)
+    named = (
+        ("substrate", substrate),
+        (("layer $i", material(l)) for (i, l) in enumerate(layers))...,
+    )
+    for (where, mat) in named
+        cls = _material_class(mat)
+        cls === want && continue
+        throw(
+            ArgumentError(
+                "Cannot mix material classes in one Multilayer: the incident medium " *
+                "is $want ($(nameof(typeof(incident)))), but $where is $cls " *
+                "($(nameof(typeof(mat)))). Use MultiphysicsMaterial to give a layer " *
+                "both electromagnetic and elastic parameters.",
+            ),
+        )
+    end
+    return nothing
+end
+
 # Constructor with automatic type promotion
 function Multilayer(layers::Vector{<:Layer}, incident::Material, substrate::Material)
+    _assert_same_material_class_stack(incident, substrate, layers)
+
     # Promote all materials to common type
     M = promote_type(typeof(incident), typeof(substrate))
     for l in layers

--- a/src/tmm/layers.jl
+++ b/src/tmm/layers.jl
@@ -69,8 +69,13 @@ function Multilayer(layers::Vector{<:Layer}, incident::Material, substrate::Mate
         M = promote_type(M, typeof(material(l)))
     end
 
-    # Convert layers
-    converted_layers = [Layer(convert(M, material(l)), thickness(l)) for l in layers]
+    # Convert layers. The element type has to be Layer{M}, not whatever concrete
+    # type each material happens to have: when M is abstract (a legal mixture such
+    # as IsotropicElastic with ElasticVoid) the inferred Layer{IsotropicElastic}
+    # does not convert to Layer{ElasticMaterial}.
+    converted_layers = Layer{M}[
+        Layer{M}(convert(M, material(l)), thickness(l)) for l in layers
+    ]
 
     return Multilayer{M}(converted_layers, convert(M, incident), convert(M, substrate))
 end

--- a/src/tmm/matrices.jl
+++ b/src/tmm/matrices.jl
@@ -133,6 +133,12 @@ function _get_n(mat::MultiphysicsMaterial)
     return _get_n(mat.photonic)
 end
 
+# Helper function to get the elastic side of a material. The acoustic routines
+# below work on velocities and impedances, which a MultiphysicsMaterial keeps on
+# its elastic half.
+_elastic_of(mat::ElasticMaterial) = mat
+_elastic_of(mat::MultiphysicsMaterial) = mat.elastic
+
 # ============================================================================
 # Phononic (elastic wave) support
 # ============================================================================
@@ -159,6 +165,8 @@ function acoustic_impedance(mat::ElasticVoid)
     c = longitudinal_velocity(mat)
     return ρ * c
 end
+
+acoustic_impedance(mat::MultiphysicsMaterial) = acoustic_impedance(mat.elastic)
 
 """
     acoustic_fresnel(Z1, Z2) -> (r, t)
@@ -199,9 +207,9 @@ Calculate the 2×2 propagation matrix for an elastic layer.
 - `λ`: Wavelength (in physical units matching d)
 """
 function acoustic_propagation_matrix(
-    mat::Union{IsotropicElastic,ElasticVoid}, d::Real, λ::Real
+    mat::Union{ElasticMaterial,MultiphysicsMaterial}, d::Real, λ::Real
 )
-    c = longitudinal_velocity(mat)
+    c = longitudinal_velocity(_elastic_of(mat))
     # Phase: δ = k*d = 2π*d/λ (wavelength in the material)
     # For physical wavelength λ in incident medium, we need λ_mat = λ * c_mat / c_inc
     # But for TMM we use wavelength directly
@@ -219,7 +227,8 @@ Calculate the 2×2 interface matrix for elastic waves.
 - `mat2`: Material on transmitted side
 """
 function acoustic_interface_matrix(
-    mat1::Union{IsotropicElastic,ElasticVoid}, mat2::Union{IsotropicElastic,ElasticVoid}
+    mat1::Union{ElasticMaterial,MultiphysicsMaterial},
+    mat2::Union{ElasticMaterial,MultiphysicsMaterial},
 )
     Z1 = acoustic_impedance(mat1)
     Z2 = acoustic_impedance(mat2)
@@ -239,7 +248,9 @@ Calculate the total transfer matrix for a phononic multilayer structure.
 # Returns
 - 2×2 complex transfer matrix
 """
-function system_matrix_acoustic(ml::Multilayer{<:ElasticMaterial}, λ::Real)
+function system_matrix_acoustic(
+    ml::Multilayer{<:Union{ElasticMaterial,MultiphysicsMaterial}}, λ::Real
+)
     # Start with identity
     M = ComplexF64[1 0; 0 1]
 

--- a/src/tmm/matrices.jl
+++ b/src/tmm/matrices.jl
@@ -128,6 +128,11 @@ function _get_n(mat::LossyDielectric)
     return sqrt(mat.ε * mat.μ)
 end
 
+function _get_n(mat::MultiphysicsMaterial)
+    # Only the electromagnetic side has a refractive index
+    return _get_n(mat.photonic)
+end
+
 # ============================================================================
 # Phononic (elastic wave) support
 # ============================================================================

--- a/src/tmm/solver.jl
+++ b/src/tmm/solver.jl
@@ -25,6 +25,29 @@ struct TMMSolver{W<:WaveType,M<:Material}
     structure::Multilayer{M}
 end
 
+# Reject a wave family the stack has no parameters for, with the same rule the PWE
+# solver uses. Note the inner constructor must be called by its parametric name:
+# writing TMMSolver(wavetype, structure) here would recurse forever.
+function TMMSolver(wavetype::W, structure::Multilayer{M}) where {W<:WaveType,M<:Material}
+    _assert_wave_matches_stack(wavetype, structure)
+    return TMMSolver{W,M}(wavetype, structure)
+end
+
+function _assert_wave_matches_stack(wave::WaveType, structure::Multilayer)
+    have = _material_class(structure.incident)
+    have === :multiphysics && return nothing
+    need = _required_material_class(wave)
+    have === need && return nothing
+    return throw(
+        ArgumentError(
+            "$(nameof(typeof(wave))) needs $need material parameters, but this " *
+            "multilayer is $have ($(nameof(typeof(structure.incident)))). Build the " *
+            "stack from $need materials, or from MultiphysicsMaterial to serve both " *
+            "wave families.",
+        ),
+    )
+end
+
 """
     TMMResult
 

--- a/test/test_material.jl
+++ b/test/test_material.jl
@@ -92,3 +92,150 @@ end
     @test_throws ErrorException Dielectric("invalid")
     @test_throws ErrorException Dielectric([1.0, 2.0])  # wrong type
 end
+
+@testset "MultiphysicsMaterial" begin
+    # IsotropicElastic positional order is (rho, C11, C12, C44)
+    si_ph = Dielectric(11.7)
+    si_el = IsotropicElastic(2330.0, 165.7e9, 63.9e9, 79.6e9)
+
+    @testset "Construction" begin
+        # Both argument orders construct, and both store the same way
+        mp = MultiphysicsMaterial(si_ph, si_el)
+        pm = MultiphysicsMaterial(si_el, si_ph)
+
+        @test mp isa MultiphysicsMaterial
+        @test pm isa MultiphysicsMaterial
+        @test mp isa Material
+
+        for m in (mp, pm)
+            @test m.photonic isa PhotonicMaterial
+            @test m.elastic isa ElasticMaterial
+            @test m.photonic === si_ph
+            @test m.elastic === si_el
+        end
+
+        # A void is a legitimate elastic side
+        @test MultiphysicsMaterial(Dielectric(1.0), ElasticVoid()) isa MultiphysicsMaterial
+    end
+
+    @testset "Same-family pairs do not construct" begin
+        @test_throws MethodError MultiphysicsMaterial(Dielectric(1.0), Dielectric(11.7))
+        @test_throws MethodError MultiphysicsMaterial(si_el, ElasticVoid())
+    end
+
+    @testset "Property delegation" begin
+        mp = MultiphysicsMaterial(si_ph, si_el)
+
+        # Photonic side: the four symbols discretize actually asks for
+        @test PhoXonic.get_property(mp, :ε) == PhoXonic.get_property(si_ph, :ε)
+        @test PhoXonic.get_property(mp, :μ) == PhoXonic.get_property(si_ph, :μ)
+        @test PhoXonic.get_property(mp, :ε_inv) == PhoXonic.get_property(si_ph, :ε_inv)
+        @test PhoXonic.get_property(mp, :μ_inv) == PhoXonic.get_property(si_ph, :μ_inv)
+
+        # Elastic side: the four symbols discretize actually asks for
+        @test PhoXonic.get_property(mp, :ρ) == PhoXonic.get_property(si_el, :ρ)
+        @test PhoXonic.get_property(mp, :C11) == PhoXonic.get_property(si_el, :C11)
+        @test PhoXonic.get_property(mp, :C12) == PhoXonic.get_property(si_el, :C12)
+        @test PhoXonic.get_property(mp, :C44) == PhoXonic.get_property(si_el, :C44)
+
+        # An unknown property must still be an error, not a silent fallback
+        @test_throws Union{ErrorException,ArgumentError} PhoXonic.get_property(mp, :nope)
+    end
+end
+
+@testset "Geometry material-class validation" begin
+    lat = square_lattice(1.0)
+    circle = Circle([0.0, 0.0], 0.2)
+
+    air = Dielectric(1.0)
+    rod = Dielectric(11.7)
+    lossy = LossyDielectric(2.25 + 0.01im)
+
+    steel = IsotropicElastic(7800.0, 280e9, 130e9, 75e9)
+    void = ElasticVoid()
+
+    mp_bg = MultiphysicsMaterial(air, void)
+    mp_incl = MultiphysicsMaterial(rod, steel)
+
+    @testset "Coherent geometries are accepted" begin
+        # All photonic
+        @test Geometry(lat, air, [(circle, rod)]) isa Geometry
+        # Photonic promotion across Dielectric and LossyDielectric stays legal
+        @test Geometry(lat, air, [(circle, lossy)]) isa Geometry
+        # All elastic, including the void
+        @test Geometry(lat, steel, [(circle, steel)]) isa Geometry
+        @test Geometry(lat, steel, [(circle, void)]) isa Geometry
+        # All multiphysics
+        @test Geometry(lat, mp_bg, [(circle, mp_incl)]) isa Geometry
+    end
+
+    @testset "Mixed classes are rejected at construction" begin
+        @test_throws ArgumentError Geometry(lat, air, [(circle, steel)])
+        @test_throws ArgumentError Geometry(lat, steel, [(circle, air)])
+        @test_throws ArgumentError Geometry(lat, mp_bg, [(circle, rod)])
+        @test_throws ArgumentError Geometry(lat, air, [(circle, mp_incl)])
+        @test_throws ArgumentError Geometry(lat, mp_bg, [(circle, steel)])
+        @test_throws ArgumentError Geometry(lat, steel, [(circle, mp_incl)])
+    end
+
+    @testset "The message names the problem" begin
+        err = try
+            Geometry(lat, air, [(circle, steel)])
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("Cannot mix material classes in one Geometry", err.msg)
+    end
+end
+
+@testset "Solver wave/material compatibility" begin
+    lat = square_lattice(1.0)
+    circle = Circle([0.0, 0.0], 0.2)
+    res = (16, 16)
+
+    air = Dielectric(1.0)
+    rod = Dielectric(11.7)
+    steel = IsotropicElastic(7800.0, 280e9, 130e9, 75e9)
+    void = ElasticVoid()
+
+    geo_ph = Geometry(lat, air, [(circle, rod)])
+    geo_el = Geometry(lat, steel, [(circle, void)])
+    geo_mp = Geometry(
+        lat, MultiphysicsMaterial(air, void), [(circle, MultiphysicsMaterial(rod, steel))]
+    )
+
+    @testset "Matching families construct" begin
+        @test Solver(TEWave(), geo_ph, res; cutoff=3) isa Solver
+        @test Solver(TMWave(), geo_ph, res; cutoff=3) isa Solver
+        @test Solver(SHWave(), geo_el, res; cutoff=3) isa Solver
+        @test Solver(PSVWave(), geo_el, res; cutoff=3) isa Solver
+    end
+
+    @testset "Multiphysics satisfies either family" begin
+        @test Solver(TEWave(), geo_mp, res; cutoff=3) isa Solver
+        @test Solver(TMWave(), geo_mp, res; cutoff=3) isa Solver
+        @test Solver(SHWave(), geo_mp, res; cutoff=3) isa Solver
+        @test Solver(PSVWave(), geo_mp, res; cutoff=3) isa Solver
+    end
+
+    @testset "Mismatched families are rejected at Solver construction" begin
+        @test_throws ArgumentError Solver(SHWave(), geo_ph, res; cutoff=3)
+        @test_throws ArgumentError Solver(PSVWave(), geo_ph, res; cutoff=3)
+        @test_throws ArgumentError Solver(TEWave(), geo_el, res; cutoff=3)
+        @test_throws ArgumentError Solver(TMWave(), geo_el, res; cutoff=3)
+    end
+
+    @testset "The message names the wave and the structure" begin
+        err = try
+            Solver(SHWave(), geo_ph, res; cutoff=3)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("SHWave", err.msg)
+        @test occursin("elastic", err.msg)
+    end
+end

--- a/test/tmm/test_layers.jl
+++ b/test/tmm/test_layers.jl
@@ -130,12 +130,59 @@ end
     end
 
     @testset "Multiphysics actually computes, not just constructs" begin
-        # This is the point of B-14: _get_n reads mat.ε directly, so a
-        # MultiphysicsMaterial stack has to reach the photonic side.
+        # Constructing is not the same as reaching the material. The photonic
+        # side reads mat.ε and the elastic side reads the velocities, so both
+        # paths have to be run, not merely built.
         solver = TMMSolver(Photonic1D(), ml_mp)
         r = tmm_spectrum(solver, 600.0)
         @test r.R >= 0.0
         @test r.T >= 0.0
         @test r.R + r.T + r.A ≈ 1.0 atol = 1e-8
+    end
+end
+
+@testset "Multiphysics through the phononic TMM path" begin
+    # Same materials and geometry as test_phononic.jl, wrapped so that each
+    # region also carries an electromagnetic side. The elastic numbers must not
+    # depend on that wrapping.
+    steel = IsotropicElastic(; ρ=7800.0, λ=115e9, μ=82e9)
+    epoxy = IsotropicElastic(; ρ=1180.0, λ=4.43e9, μ=1.59e9)
+
+    d = 0.001          # 1 mm
+    λ_long = 10 * d    # λ = 10 mm >> d
+
+    mp_steel = MultiphysicsMaterial(Dielectric(11.7), steel)
+    mp_epoxy = MultiphysicsMaterial(Dielectric(3.6), epoxy)
+
+    ml_plain = Multilayer([Layer(steel, d)], epoxy, epoxy)
+    ml_mp = Multilayer([Layer(mp_steel, d)], mp_epoxy, mp_epoxy)
+
+    @testset "tmm_spectrum" begin
+        plain = tmm_spectrum(TMMSolver(Longitudinal1D(), ml_plain), λ_long)
+        mp = tmm_spectrum(TMMSolver(Longitudinal1D(), ml_mp), λ_long)
+
+        @test mp.R ≈ plain.R
+        @test mp.T ≈ plain.T
+        @test mp.R + mp.T + mp.A ≈ 1.0 atol = 1e-8
+    end
+
+    @testset "tmm_bandstructure" begin
+        # A separate entry point, and it reaches the material through its own
+        # code path rather than through system_matrix_acoustic.
+        unit = [Layer(steel, d), Layer(epoxy, 2d)]
+        unit_mp = [Layer(mp_steel, d), Layer(mp_epoxy, 2d)]
+
+        plain = tmm_bandstructure(
+            TMMSolver(Longitudinal1D(), Multilayer(unit, epoxy, epoxy));
+            k_points=5,
+            bands=1:2,
+        )
+        mp = tmm_bandstructure(
+            TMMSolver(Longitudinal1D(), Multilayer(unit_mp, mp_epoxy, mp_epoxy));
+            k_points=5,
+            bands=1:2,
+        )
+
+        @test mp.frequencies ≈ plain.frequencies
     end
 end

--- a/test/tmm/test_layers.jl
+++ b/test/tmm/test_layers.jl
@@ -77,3 +77,65 @@ end
         @test thickness(layers(ml)[2]) ≈ d_lo
     end
 end
+
+@testset "Multilayer material-class validation" begin
+    air = Dielectric(1.0)
+    glass = Dielectric(2.25)
+    steel = IsotropicElastic(7800.0, 280e9, 130e9, 75e9)
+    epoxy = IsotropicElastic(1180.0, 7.61e9, 4.43e9, 1.59e9)
+
+    mp_air = MultiphysicsMaterial(air, ElasticVoid())
+    mp_glass = MultiphysicsMaterial(glass, steel)
+
+    @testset "Coherent stacks are accepted" begin
+        @test Multilayer([Layer(glass, 100.0)], air, air) isa Multilayer
+        @test Multilayer([Layer(steel, 1.0)], epoxy, epoxy) isa Multilayer
+        @test Multilayer([Layer(mp_glass, 100.0)], mp_air, mp_air) isa Multilayer
+    end
+
+    @testset "Mixed classes are rejected" begin
+        @test_throws ArgumentError Multilayer([Layer(steel, 1.0)], air, air)
+        @test_throws ArgumentError Multilayer([Layer(glass, 100.0)], epoxy, epoxy)
+        @test_throws ArgumentError Multilayer([Layer(mp_glass, 100.0)], air, air)
+    end
+end
+
+@testset "TMMSolver wave/material compatibility" begin
+    air = Dielectric(1.0)
+    glass = Dielectric(2.25)
+    steel = IsotropicElastic(7800.0, 280e9, 130e9, 75e9)
+    epoxy = IsotropicElastic(1180.0, 7.61e9, 4.43e9, 1.59e9)
+
+    ml_ph = Multilayer([Layer(glass, 100.0)], air, air)
+    ml_el = Multilayer([Layer(steel, 1.0)], epoxy, epoxy)
+    ml_mp = Multilayer(
+        [Layer(MultiphysicsMaterial(glass, steel), 100.0)],
+        MultiphysicsMaterial(air, ElasticVoid()),
+        MultiphysicsMaterial(air, ElasticVoid()),
+    )
+
+    @testset "Matching families construct" begin
+        @test TMMSolver(Photonic1D(), ml_ph) isa TMMSolver
+        @test TMMSolver(Longitudinal1D(), ml_el) isa TMMSolver
+    end
+
+    @testset "Multiphysics serves either family" begin
+        @test TMMSolver(Photonic1D(), ml_mp) isa TMMSolver
+        @test TMMSolver(Longitudinal1D(), ml_mp) isa TMMSolver
+    end
+
+    @testset "Mismatched families are rejected" begin
+        @test_throws ArgumentError TMMSolver(Photonic1D(), ml_el)
+        @test_throws ArgumentError TMMSolver(Longitudinal1D(), ml_ph)
+    end
+
+    @testset "Multiphysics actually computes, not just constructs" begin
+        # This is the point of B-14: _get_n reads mat.ε directly, so a
+        # MultiphysicsMaterial stack has to reach the photonic side.
+        solver = TMMSolver(Photonic1D(), ml_mp)
+        r = tmm_spectrum(solver, 600.0)
+        @test r.R >= 0.0
+        @test r.T >= 0.0
+        @test r.R + r.T + r.A ≈ 1.0 atol = 1e-8
+    end
+end

--- a/test/tmm/test_layers.jl
+++ b/test/tmm/test_layers.jl
@@ -40,6 +40,17 @@ end
     @test layers(ml)[2] === layer2
 end
 
+@testset "Multilayer with mixed elastic materials" begin
+    # A solid layer in a void: the ordinary phononic stack, and the mixture
+    # promote_rule has always allowed. It lands on the abstract ElasticMaterial,
+    # which is where the layer element type used to be lost.
+    steel = IsotropicElastic(7800.0, 280e9, 130e9, 75e9)
+    ml = Multilayer([Layer(steel, 1.0)], ElasticVoid(), ElasticVoid())
+
+    @test ml isa Multilayer{ElasticMaterial}
+    @test nlayers(ml) == 1
+end
+
 @testset "Helper functions" begin
     @testset "periodic_multilayer" begin
         air = Dielectric(1.0)


### PR DESCRIPTION
Closes #103.
Closes #104.

Together these make one structure usable through every supported path — PWE and
TMM, photonic and phononic — and move the failure for an inconsistent structure
from the middle of a calculation to its construction.

Three commits, kept separate so the pre-existing defect stays revertible on its
own; the first was tested with the other two stashed, so a bisect that lands
there finds a working tree. `examples/214` is left untouched, so the
two-geometry form stays available for comparison.

## Verification

| | before | after |
|---|---|---|
| core tests | 1802 | **1874** |
| TMM tests | 243 | **262** |
| `examples/214b` vs `214` | — | **identical gap numbers** |
| format | clean | clean |
